### PR TITLE
Add youtube shortcode

### DIFF
--- a/layouts/partials/scientific-python-theme-css.html
+++ b/layouts/partials/scientific-python-theme-css.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" type="text/css" href="{{ "css/news.css" | relURL }}" />
 <link rel="stylesheet" type="text/css" href="{{ "css/keyfeatures.css" | relURL }}" />
 <link rel="stylesheet" type="text/css" href="{{ "css/tables.css" | relURL }}" />
+<link rel="stylesheet" type="text/css" href="{{ "css/videos.css" | relURL }}" />
 
 <!-- Custom CSS -->
 <!-- All CSS files under assets/css are compiled (as templates) and then included -->

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,0 +1,32 @@
+{{ $title := .Get "title" }}
+{{ $venue := .Get "venue" }}
+{{ $author := .Get "author" }}
+{{ $date := .Get "date" }}
+{{ $transcript := .Inner | markdownify }}
+
+<div class="youtube">
+  <h2 class="video-title">
+    {{ $title }}
+  </h2>
+  <iframe src="https://www.youtube.com/embed/{{ .Get "id" }}?enablejsapi=1{{ with .Get "color" }}{{ if eq . "white" }}&color=white{{ end }}{{ end }}{{ with .Get "autoplay" }}{{ if eq . "true" }}&autoplay=1{{ end }}{{ end }}{{ if isset .Params "yt_start" }}&start={{ .Get "yt_start" }}{{ end }}{{ if isset .Params "yt_end" }}&end={{ .Get "yt_end" }}{{ end }}&modestbranding=0" allowfullscreen class="youtube"></iframe>
+  <div class="video-meta">
+    {{if $author }}
+    <div class="video-author">
+      {{ $author }}
+    </div>
+    {{ end }}
+    {{ if $venue }}
+    <div class="video-venue">
+      {{ $venue }}
+    </div>
+    {{ end }}
+    {{ if $date }}
+    <div class="video-date">
+      {{ $date }}
+    </div>
+    {{ end }}
+  </div>
+  <div class="video-transcript">
+    {{ $transcript }}
+  </div>
+</div>

--- a/static/css/videos.css
+++ b/static/css/videos.css
@@ -1,0 +1,23 @@
+.youtube {
+  margin-bottom: 1.5rem;
+}
+
+.youtube iframe {
+  width: 100%;
+  height: 30rem;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.youtube .video-meta {
+  padding-top: 0.75rem;
+  padding-bottom: 1.5rem;
+}
+
+.youtube .video-title {
+}
+
+.youtube .video-meta {
+  font-weight: bold;
+  padding-bottom: 0.5rem;
+}


### PR DESCRIPTION
Example usage:

```
{{< youtube id="ezL7j4nSXpQ" class="talk" title="Complex network analysis with NetworkX" venue="PyData Global 2020" author="Jarrod Millman" />}}

{{< youtube id="lLrCRiH-fQo" class="talk" title="Developing Scientific Open Source Software" venue="IE 2021" author="Stefan van der Walt" />}}


{{< youtube id="EmGSSbwdCZQ" class="talk" title="Open Data Science" venue="CU Denver Data Science Symposium 2020" author="Stefan van der Walt" >}}

Here, I will give a transcript of the whole video, and say some things about it that you cannot know otherwise without watching the **video**.

### But what is it?

This is it!

{{< /youtube >}}
```