### PR TITLE
Document shortcodes

### DIFF
--- a/doc/content/getstarted.md
+++ b/doc/content/getstarted.md
@@ -1,8 +1,6 @@
 ---
 title: Get Started
 sidebar: true
-sidebarlogo: fresh-white
-include_footer: false
 ---
 
 ## The Scientific Python theme for Hugo
@@ -11,9 +9,9 @@ The **Scientific Python Hugo Theme** is a theme for the
 [Hugo](https://gohugo.io) static site generator built on the
 [Fresh](https://github.com/StefMa/hugo-fresh) theme.
 
-To use the theme, you will need to [download
-hugo](https://github.com/gohugoio/hugo/releases) and place it on your
-path.
+To use the theme, you will need to
+[download hugo](https://github.com/gohugoio/hugo/releases)
+and place it on your path.
 
 ## Getting started
 
@@ -56,6 +54,10 @@ Edit `config.yaml` to your liking.
 
 To customize CSS, add a `custom.css` (or `anything-you-want.css`) file in the `assets/css` directory.
 These files can be plain CSS, or can use Hugo templating constructs.
+
+## Shortcodes
+
+See [shortcodes]({{< relref "shortcodes" >}}).
 
 ## Example sites
 

--- a/doc/content/shortcodes.md
+++ b/doc/content/shortcodes.md
@@ -1,0 +1,100 @@
+---
+title: Shortcodes
+sidebar: true
+---
+
+## Tables
+
+```
+{{</* yamlToTable */>}}
+
+headers:
+  - Project
+  - Available Packages
+  - Download location
+
+format:
+  - align: left
+  - align: left
+  - align: right
+
+rows:
+  - columns:
+      - "NumPy"
+      - |
+        Official *source code* (all platforms) and *binaries* for<br/>
+        **Windows**, **Linux**, and **Mac OS X**
+      - "[PyPi page for NumPy](https://pypi.python.org/pypi/numpy)"
+
+  - columns:
+      - SciPy
+      - |
+        Official *source code* (all platforms) and *binaries* for<br/>
+        **Windows**, **Linux** and **Mac OS X**
+      - |
+        [SciPy release page](https://github.com/scipy/scipy/releases) (sources)<br/>
+        [PyPI page for SciPy](https://pypi.python.org/pypi/scipy) (all)
+
+{{</* /yamlToTable */>}}
+```
+
+{{< yamlToTable >}}
+
+headers:
+  - Project
+  - Available Packages
+  - Download location
+
+format:
+  - align: left
+  - align: left
+  - align: right
+
+rows:
+  - columns:
+      - "NumPy"
+      - |
+        Official *source code* (all platforms) and *binaries* for<br/>
+        **Windows**, **Linux**, and **Mac OS X**
+      - "[PyPi page for NumPy](https://pypi.python.org/pypi/numpy)"
+
+  - columns:
+      - SciPy
+      - |
+        Official *source code* (all platforms) and *binaries* for<br/>
+        **Windows**, **Linux** and **Mac OS X**
+      - |
+        [SciPy release page](https://github.com/scipy/scipy/releases) (sources)<br/>
+        [PyPI page for SciPy](https://pypi.python.org/pypi/scipy) (all)
+
+{{< /yamlToTable >}}
+
+## Youtube videos
+
+```
+{{</* youtube id="lLrCRiH-fQo" class="talk" title="Developing Scientific Open Source Software" venue="IE 2021" author="Stefan van der Walt" *//>}}
+
+{{< youtube id="lLrCRiH-fQo" class="talk" title="Developing Scientific Open Source Software" venue="IE 2021" author="Stefan van der Walt" />}}
+
+
+{{</* youtube id="EmGSSbwdCZQ" class="talk" title="Open Data Science" venue="CU Denver Data Science Symposium 2020" author="Stefan van der Walt" */>}}
+
+Here, I will give a transcript of the whole video, and say some things about it that you cannot know otherwise without watching the **video**.
+
+### But what is it?
+
+This is it!
+
+{{</* /youtube */>}}
+```
+
+
+{{< youtube id="EmGSSbwdCZQ" class="talk" title="Open Data Science" venue="CU Denver Data Science Symposium 2020" author="Stefan van der Walt" >}}
+
+Here, I will give a transcript of the whole video, and say some things about it that you cannot know otherwise without watching the **video**.
+
+### But what is it?
+
+This is it!
+
+{{< /youtube >}}


### PR DESCRIPTION
@stefanv  I wasn't sure how to make the shortcode markdown visible.  I ended up copying the shortcode examples and, on the first copy, I surrounded the block with three backticks (only really needed when there is markdown inside the block, e.g., youtube transcript) and then putting the shortcode command inside `/* <shortcode command> */`.  You will see what I mean.

Maybe there should be a shortcode for wrapping shortcode examples.  It would print the text as is with the output below it.  Maybe the command could be collapsible.