### PR TITLE
Restyle blockquotes

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -253,21 +253,14 @@ figcaption {
 }
 
 blockquote {
-    margin: 10px;
+    border-left: 6px solid rgb(238, 238, 238);
+    margin-top: 1rem;
+    margin-bottom: 1rem;
 }
 
 blockquote p {
-    padding: 15px;
-    background: var(--colorSecondary);
-    border-radius: 5px;
-}
-
-blockquote p::before {
-    content: '\201C';
-}
-
-blockquote p::after {
-    content: '\201D';
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 @media only screen and (max-width: 850px) {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -253,7 +253,7 @@ figcaption {
 }
 
 blockquote {
-    border-left: 6px solid rgb(238, 238, 238);
+    border-left: 6px solid var(--colorSecondary);
     margin-top: 1rem;
     margin-bottom: 1rem;
 }


### PR DESCRIPTION
- Entire block is formatted as a unit when you do:

```
  > paragraph 1
  >
  > paragraph 2
```

- Quotes are no longer automatically inserted around each paragraph of a blockquote
- Style is changed from dark background blob to a thick gray line on the left

Example:
<img src="https://user-images.githubusercontent.com/45071/138218904-061689ae-b0a7-4605-b78a-f63ae42bc117.png" width="600px"/>

Running this by the @scientific-python/theme-team since it will also impact numpy.org