### PR TITLE
Add team support

### DIFF
--- a/assets/sass/teams.scss
+++ b/assets/sass/teams.scss
@@ -1,0 +1,30 @@
+.team {
+}
+
+.team .members {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.team .member {
+  padding-right: 1.25rem;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+  width: 11rem;
+  text-align: center;
+  vertical-align: top;
+}
+
+.team .member .photo {
+  display: block;
+}
+
+.team .member .photo img {
+    width: 60px;
+    border-radius: 50%;
+    margin-bottom: 0.5rem;
+}
+
+.team .member .name {
+    font-weight: bold;
+}

--- a/layouts/partials/scientific-python-theme-css.html
+++ b/layouts/partials/scientific-python-theme-css.html
@@ -5,7 +5,7 @@
 <!-- Theme CSS -->
 {{ $cssFiles := (slice
                    "styles" "content" "news" "keyfeatures"
-                   "tables" "videos" "posts"
+                   "tables" "videos" "posts" "teams"
                 ) }}
 {{- range $cssFiles -}}
 {{- $sassFile := printf "sass/%s.scss" . -}}

--- a/layouts/shortcodes/team.html
+++ b/layouts/shortcodes/team.html
@@ -1,0 +1,6 @@
+<div class="team">
+  <h6 class="title">{{ .Get "name" }}</h6>
+  <div class="members">
+    {{ .Inner }}
+  </div>
+</div>

--- a/layouts/shortcodes/team_member.html
+++ b/layouts/shortcodes/team_member.html
@@ -1,0 +1,12 @@
+<div class="member">
+  <a href="{{ .Get "url" }}" class="name">
+    <div class="photo">
+      <img
+        src="{{ .Get "avatarUrl" }}"
+        loading="lazy"
+        alt="Avatar of {{ .Get "name" }}"
+      />
+    </div>
+    {{ .Get "name" }}
+  </a>
+</div>

--- a/tools/team_query.py
+++ b/tools/team_query.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import requests
+import string
+import textwrap
+import argparse
+
+
+team_query = string.Template("""
+  query {
+    organization(login: "$org") {
+      team(slug: "$team") {
+        members(first: 100, orderBy: {field: LOGIN, direction: ASC}) {
+          nodes {
+            login
+            name
+            url
+            avatarUrl
+          }
+        }
+      }
+    }
+  }
+""")
+
+
+def api(query):
+    request = requests.post(
+        'https://api.github.com/graphql',
+        json={'query': query},
+        headers={'Authorization': f'bearer {token}'}
+    )
+    if request.status_code == 200:
+        return request.json()
+    else:
+        raise RuntimeError("Request received HTTP {request.status_code}: {query}")
+
+
+parser = argparse.ArgumentParser(description='Generate team gallery from GitHub')
+parser.add_argument('--org', required=True, help='GitHub organization name')
+parser.add_argument('--team', required=True, help='Team name in the organization')
+parser.add_argument('--title', help='Title for gallery entry (defaults to team name)')
+args = parser.parse_args()
+
+org = args.org
+team = args.team
+title = args.title if args.title else args.team 
+
+
+token = os.environ.get('GH_TOKEN', None)
+if token is None:
+    print("No token found.  Please export a GH_TOKEN with permissions "
+          "to read team members.")
+    sys.exit(-1)
+
+
+resp = api(team_query.substitute(org=org, team=team))
+members = resp['data']['organization']['team']['members']['nodes']
+
+print('---')
+print('---')
+print(f'{{{{< team org="{org}" name="{title}" >}}}}')
+for m in members:
+    print('  ' + textwrap.dedent(f'''\
+      {{{{< team_member
+            login="{m["login"]}"
+            name="{m["name"]}"
+            url="{m["url"]}"
+            avatarUrl="{m["avatarUrl"]}" >}}}}
+    '''))
+print("{{< /team >}}")


### PR DESCRIPTION
The `team_query.py` file gets a list of team members from GitHub.  To
use it, you will need to set the GH_TOKEN environment variable
to a personal access token.

The team is rendered using shortcodes (`team`, `team_member`).

Example usage:

```
python team_query.py --org scientific-python --team spec-steering-committee --title "Spec Steering Committee" > content/en/teams/spec-steering-committee.md
```