### PR TITLE
Always use relative links (.RelPermalink) instead of full URLs (.Permalink)

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
     <!-- Refer: https://regisphilibert.com/blog/2018/08/hugo-multilingual-part-1-managing-content-translation/ -->
     {{ if .IsTranslated }}
       {{ range .Translations }}
-      <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}" />
+      <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}" />
       {{ end }}
     {{ end }}
     {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -13,7 +13,7 @@
     <!-- Refer: https://regisphilibert.com/blog/2018/08/hugo-multilingual-part-1-managing-content-translation/ -->
     {{ if .IsTranslated }}
       {{ range .Translations }}
-      <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}" />
+      <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}" />
       {{ end }}
     {{ end }}
     {{ template "_internal/twitter_cards.html" . }}
@@ -48,7 +48,7 @@
       {{ range .Pages }}
       <div class="post-list">
         <article>
-          <div class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></div>
+          <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
           <div class="post-authors">
             {{- range .Params.Authors -}}
             <div class="post-author">{{ . }}</div>


### PR DESCRIPTION
This ensures that links work even when the site is deployed on a
different domain (such as the Netlify preview domain).

This should address the news linking issues faced in https://github.com/scientific-python/scientific-python.org/pull/119