### PR TITLE
Add a shortcode to render and include markdown

### DIFF
--- a/doc/content/example-markdown.md
+++ b/doc/content/example-markdown.md
@@ -1,0 +1,1 @@
+This is some *example markdown* with **bold**!

--- a/layouts/shortcodes/include-md.html
+++ b/layouts/shortcodes/include-md.html
@@ -1,0 +1,10 @@
+{{/*
+
+doc: Render and include a markdown file.
+
+{{< include-md "example-markdown.md" >}}
+
+*/}}
+
+{{ $file := .Get 0 }}
+{{ with .Page.GetPage $file }}{{ .Content }}{{ end }}


### PR DESCRIPTION
@tupui Here's the promised shortcode.

I followed a [different tactic for scientific-python.org](https://github.com/scientific-python/scientific-python.org/pull/129/files#diff-383abe2a95758bff4e9ba060bc1ea9788b4527435c7144aa301b0dc4c7734e1dR1), but only because I was lazy and did not want to keep adding teams by hand.

In retrospect, this would have been simpler.