### PR TITLE
Generate team galleries in HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 \#*
+.hugo_build.lock
 
 # Auto-generated
 doc/content/shortcodes.md

--- a/assets/css/teams.css
+++ b/assets/css/teams.css
@@ -1,4 +1,5 @@
 .team {
+  padding-bottom: 2rem;
 }
 
 .team .members {

--- a/doc/static/example.html
+++ b/doc/static/example.html
@@ -1,0 +1,1 @@
+This is some example HTML with <em>italic</em> and <b>bold</b> text.

--- a/layouts/shortcodes/include-html.html
+++ b/layouts/shortcodes/include-html.html
@@ -1,0 +1,10 @@
+{{/*
+
+doc: Include an HTML file. The filename is specified relative to the root path.
+
+{{< include-html "static/example.html" >}}
+
+*/}}
+
+{{ $file := .Get 0 }}
+{{ $file | readFile | safeHTML }}

--- a/tools/team_query.py
+++ b/tools/team_query.py
@@ -4,12 +4,14 @@ import requests
 import string
 import textwrap
 import argparse
+import string
 
 
 team_query = string.Template("""
   query {
     organization(login: "$org") {
       team(slug: "$team") {
+        name,
         members(first: 100, orderBy: {field: LOGIN, direction: ASC}) {
           nodes {
             login
@@ -39,13 +41,10 @@ def api(query):
 parser = argparse.ArgumentParser(description='Generate team gallery from GitHub')
 parser.add_argument('--org', required=True, help='GitHub organization name')
 parser.add_argument('--team', required=True, help='Team name in the organization')
-parser.add_argument('--title', help='Title for gallery entry (defaults to team name)')
 args = parser.parse_args()
 
 org = args.org
 team = args.team
-title = args.title if args.title else args.team
-
 
 token = os.environ.get('GH_TOKEN', None)
 if token is None:
@@ -56,18 +55,34 @@ if token is None:
 
 resp = api(team_query.substitute(org=org, team=team))
 members = resp['data']['organization']['team']['members']['nodes']
+team_name = resp['data']['organization']['team']['name']
 
-print('---')
-print(f'title: {title}')
-print(f'org: {org}')
-print('---')
-print(f'{{{{< team org="{org}" name="{title}" >}}}}')
-for m in members:
-    print('  ' + textwrap.dedent(f'''\
-      {{{{< team_member
-            login="{m["login"]}"
-            name="{m["name"] or m["login"]}"
-            url="{m["url"]}"
-            avatarUrl="{m["avatarUrl"]}" >}}}}
-    '''))
-print("{{< /team >}}")
+team_template = string.Template('''
+<div class="team">
+  <h6 class="name title">${team_name}</h6>
+  <div class="members">
+    ${members}
+  </div>
+</div>
+''')
+
+member_template = string.Template('''
+    <div class="member">
+      <a href="${url}" class="name">
+        <div class="photo">
+          <img
+            src="${avatarUrl}"
+            loading="lazy"
+            alt="Avatar of ${name}"
+          />
+        </div>
+        ${name}
+      </a>
+    </div>
+''')
+
+
+members_str = ''.join([member_template.substitute(**m) for m in members])
+team_str = team_template.substitute(members=members_str, team_name=team_name)
+
+print(team_str)


### PR DESCRIPTION
Before, we generated markdown files with embedded shortcodes.
However, this made the galleries harder to include in various
places.

Now, we generate a raw HTML gallery, and provide a
shortcode (`include-html`) for pulling it in anywhere on the site.