### PR TITLE
Teams: use GH username if full name is missing

### DIFF
--- a/tools/team_query.py
+++ b/tools/team_query.py
@@ -1,10 +1,9 @@
 import os
 import sys
-import requests
-import string
-import textwrap
 import argparse
 import string
+
+import requests
 
 
 team_query = string.Template("""
@@ -81,8 +80,12 @@ member_template = string.Template('''
     </div>
 ''')
 
+members_list = []
+for m in members:
+    m["name"] = m["name"] or m["login"]
+    members_list.append(member_template.substitute(**m))
 
-members_str = ''.join([member_template.substitute(**m) for m in members])
+members_str = ''.join(members_list)
 team_str = team_template.substitute(members=members_str, team_name=team_name)
 
 print(team_str)


### PR DESCRIPTION
When changing the teams generation code from rendering markdown to HTML, this was missing.

When there is no username, then the GH login is used.

Side note: we are using `requests`, maybe we should have a `requirements.txt` or a note somewhere about this dependency.