### PR TITLE
Remove remnants of thebe / console app

### DIFF
--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -9,18 +9,7 @@
 <!-- UIkit -->
 <script src="https://cdn.jsdelivr.net/npm/uikit@3.7.6/dist/js/uikit.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.7.6/dist/css/uikit.min.css" />
-<!-- Thebe Configuration -->
-<script type="text/x-thebe-config">
-    {
-        requestKernel: true,
-        binderOptions: {
-            repo: "joelachance/thebelab-requirements"
-        },
-    }
-</script>
 <script src="https://unpkg.com/thebe@0.8.2/lib/index.js"></script>
-<!-- app.js -->
-<script src="{{ "js/app.js" | relURL }}"></script>
 
 <script src="{{ "js/shortcuts.js" | relURL }}"></script>
 <script type="text/javascript">setupShortcuts(maxLevel={{ default 2 .Page.Params.shortcutDepth }});</script>


### PR DESCRIPTION
For `numpy.org`, we should (1) add `thebe.js` into `static/js` containing:

```html
<!-- Thebe Configuration -->
<script type="text/x-thebe-config">
    {
        requestKernel: true,
        binderOptions: {
            repo: "joelachance/thebelab-requirements"
        },
    }
</script>
```

(2) Also ensure that `static/js/app.js` is present still.