### PR TITLE
Add Makefile to example site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ The **Scientific Python Hugo Theme** is a theme for the
 [Hugo](https://gohugo.io) static site generator built on the
 [Fresh](https://github.com/StefMa/hugo-fresh) theme.
 
-Please see the [theme documentation](https://theme.scientific-python.org).
+Please see the [theme
+documentation](https://theme.scientific-python.org), especially the
+[get started](https://theme.scientific-python.org/getstarted/) page.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,34 @@
+.PHONY: help themes html serve clean
+.DEFAULT_GOAL := help
+
+help:
+	@grep ": ##" Makefile | grep -v grep | tr -d '#'
+
+themes/scientific-python-hugo-theme:
+	@if [ ! -d "$<" ]; then \
+	  echo "*** ERROR: missing theme" ; \
+	  echo ; \
+	  echo "It looks as though you are missing the themes directory."; \
+	  echo "You need to add the scientific-python-hugo-theme as a submodule."; \
+	  echo ; \
+	  echo "Please see https://theme.scientific-python.org/getstarted/"; \
+	  echo ; \
+	  exit 1; \
+	fi
+
+themes/scientific-python-hugo-theme/themes/hugo-fresh/README.md:
+	git submodule update --init --recursive
+
+themes: | themes/scientific-python-hugo-theme themes/scientific-python-hugo-theme/themes/hugo-fresh/README.md
+
+html: ## Build site in `./public`
+html: themes
+	hugo --buildDrafts
+
+serve: ## Serve site, typically on http://localhost:1313
+serve: themes
+	@hugo --i18n-warnings --buildDrafts server
+
+clean: ## Remove built files
+clean:
+	rm -rf public

--- a/doc/content/getstarted.md
+++ b/doc/content/getstarted.md
@@ -30,23 +30,17 @@ and place it on your path.
    git submodule add https://github.com/scientific-python/scientific-python-hugo-theme themes/scientific-python-hugo-theme
    ```
 
-4. Download all submodules:
+4. Build and serve your site:
 
    ```sh
-   git submodule update --init --recursive
-   ```
-
-5. Build your site:
-
-   ```sh
-   hugo serve
+   make serve
    ```
 
 Browse to `http://localhost:1313`, and hopefully you will see your new site!
 
 ## Building for production
 
-Run `hugo` and find the output in `public`.
+Run `make html`.  Output appears in `./public`.
 
 ## Customizing the site
 


### PR DESCRIPTION
Also link to the getting started guide from the README, and update the
guide to use the new make targets.

Partially addresses https://github.com/scientific-python/scientific-python-hugo-theme/issues/58 and https://github.com/scientific-python/scientific-python-hugo-theme/issues/65