### PR TITLE
Parameterize link colors inside the content section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -6,6 +6,12 @@ em {
     color: var(--colorPrimaryDark) !important;
 }
 
+/* This color came from uikit; we re-specify it here
+   to show how to override it for the content section */
+.content-padding a {
+  color: var(--colorContentLink);
+}
+
 .flex-row {
     display: flex;
     flex-direction: row;

--- a/assets/css/vars.css
+++ b/assets/css/vars.css
@@ -11,4 +11,5 @@
 
   --colorHighlight: rgb(255, 197, 83);
   --colorShadow: rgba(0, 0, 0, 0.1);
+  --colorContentLink: rgb(30, 135, 240);
 }


### PR DESCRIPTION
This should probably be one of the theme colors, such as colorPrimary
or colorPrimaryLight, but that doesn't look quite right.  So, just
making this a variable for now and leaving it with the default, that
comes from UIKit.

Closes https://github.com/scientific-python/scientific-python-hugo-theme/issues/52