### PR TITLE
Make front page fading configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ theme:
   - scientific-python-hugo-theme/themes/hugo-fresh
 
 params:
+  fadeFrontPage: false
   images:
   - /images/logo.svg
   navColor: blue

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,7 +20,7 @@
   </head>
   <body>
     <!-- Preloader. Set to true for front-page fade-in animation -->
-    {{ if .IsHome }}
+    {{ if (and .IsHome .Site.Params.fadeFrontPage) }}
     <div id="preloader"></div>
     {{ end }}
 


### PR DESCRIPTION
Will need to be re-enabled for `numpy.org` (and `scipy.org`, if they want it—@tupui).

Closes https://github.com/scientific-python/scientific-python-hugo-theme/issues/10