### PR TITLE
Fix link

### DIFF
--- a/assets/css/fresh/partials/_utils.scss
+++ b/assets/css/fresh/partials/_utils.scss
@@ -28,7 +28,7 @@ button {
     // centers the loading animation horizontally on the screen 
     top: 50%;
     // centers the loading animation vertically on the screen 
-    background-image: url(../images/loaders/rings.svg);
+    background-image: url(../../images/loaders/rings.svg);
     background-size: 80px 80px;
     // path to loading animation 
     background-repeat: no-repeat;


### PR DESCRIPTION
Closes #97.

Not sure this is the best fix.  Also,

```
[jarrod@x15 scientific-python-hugo-theme (link)]$ ls static/images/loaders/
audio.svg  ball-triangle.svg  bars.svg  circles.svg  grid.svg  hearts.svg  oval.svg  puff.svg  rings.svg  spinning-circles.svg  tail-spin.svg  three-dots.svg
[jarrod@x15 scientific-python-hugo-theme (link)]$ grep -r images/loaders
assets/css/fresh/partials/_utils.scss:    background-image: url(../../images/loaders/rings.svg);
doc/resources/_gen/assets/sass/style.sass_5ad6f408b0e3e473c748aac88af0ea18.content:  background-image: url(../images/loaders/rings.svg);
```

Are we using any of the other svgs?  Should we remove them?