### PR TITLE
Add lighthouse to netlify

### DIFF
--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -4,7 +4,7 @@
 
 [build.environment]
   PYTHON_VERSION = "3.8"
-  HUGO_VERSION = "0.91.2"
+  HUGO_VERSION = "0.92.1"
 
 [[plugins]]
   package = "@netlify/plugin-lighthouse"

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -5,3 +5,18 @@
 [build.environment]
   PYTHON_VERSION = "3.8"
   HUGO_VERSION = "0.91.2"
+
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+  # optional, fails build when a category is below a threshold
+  [plugins.inputs.thresholds]
+    performance = 0.6
+    accessibility = 0.9
+    best-practices = 0.9
+    seo = 0.9
+    pwa = 0.2
+
+  # optional, deploy the lighthouse report to a path under your site
+  [plugins.inputs]
+    output_path = "reports/lighthouse.html"


### PR DESCRIPTION
https://deploy-preview-101--scientific-python-hugo-theme.netlify.app/reports/lighthouse.html

Here is the plugin we are using:
https://github.com/netlify-labs/netlify-plugin-lighthouse

I had to do two things:

1. Installed plugin in the Netlify UI from this [direct in-app installation link](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install).
2.  Add this
```
[[plugins]]
  package = "@netlify/plugin-lighthouse"

  # optional, fails build when a category is below a threshold
  [plugins.inputs.thresholds]
    performance = 0.6
    accessibility = 0.9
    best-practices = 0.9
    seo = 0.9
    pwa = 0.2

  # optional, deploy the lighthouse report to a path under your site
  [plugins.inputs]
    output_path = "reports/lighthouse.html"
``` 
to `netlify.toml`.  I changed `performance = 0.9` and `pwa = 0.9` to  `performance = 0.6` and `pwa = 0.2` b/c otherwise the CI failed.  We should adjust the thresholds as we improve the theme.