### PR TITLE
Use /js/script.js instead of /js/plausible.js for analytics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,4 +8,4 @@ params:
     sizes: [400,900]
   plausible:
     dataDomain: null
-    javaScript: "https://analytics.scientific-python.org/js/plausible.js"
+    javaScript: "https://analytics.scientific-python.org/js/script.js"


### PR DESCRIPTION
Many ad-blockers won't allow plausible.js through unless it is run on
plausible.io itself.