### PR TITLE
Rename analytics.scientific-python.org to views.scientific-python.org

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,4 +8,4 @@ params:
     sizes: [400,900]
   plausible:
     dataDomain: null
-    javaScript: "https://analytics.scientific-python.org/js/script.js"
+    javaScript: "https://views.scientific-python.org/js/script.js"


### PR DESCRIPTION
uBlock uses EasyList/EasyPrivacy which includes a ban on analytics.*/event