### PR TITLE
Add mermaid shortcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ teams-clean:
 
 teams: | teams-clean $(patsubst %,$(TEAMS_DIR)/%.md,$(TEAMS))
 
-doc/content/shortcodes.md:
+doc/content/shortcodes.md: $(wildcard layouts/shortcodes/*.html)
 	python tools/render_shortcode_docs.py > doc/content/shortcodes.md
 
 doc-serve: doc/content/shortcodes.md

--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -47,3 +47,8 @@
     font-weight: bold;
     margin-top: 25px;
 }
+
+/* Override bulma .label font-weight, which otherwise impacts on g.label used by mermaid */
+g.label {
+  font-weight: normal;
+}

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -46,3 +46,7 @@
   }
 </script>
 {{ end }}
+
+{{ if .HasShortcode "mermaid" }}
+<script async src="https://unpkg.com/mermaid@8.14.0/dist/mermaid.min.js"></script>
+{{ end }}

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,0 +1,26 @@
+{{/*
+
+doc: Generate diagrams and flowcharts from markdown.
+
+{{< mermaid >}}
+graph LR
+
+START[ ]--> |Propose| A[Accept]
+A--> |Draft| B[Endorse]
+B--> |Recommend| C[Adopt]
+
+click A callback "Steering Committee Action"
+click B callback "Core Project Action"
+click C callback "Ecosystem Action"
+
+style START fill:#FFFFFF, stroke:#FFFFFF;
+
+{{< /mermaid >}}
+
+*/}}
+
+<!-- TODO: Move the script out of the shortcode -->
+<script async src="https://unpkg.com/mermaid@8.14.0/dist/mermaid.min.js"></script>
+<div class="mermaid">
+  {{.Inner}}
+</div>

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -19,8 +19,6 @@ style START fill:#FFFFFF, stroke:#FFFFFF;
 
 */}}
 
-<!-- TODO: Move the script out of the shortcode -->
-<script async src="https://unpkg.com/mermaid@8.14.0/dist/mermaid.min.js"></script>
 <div class="mermaid">
   {{.Inner}}
 </div>


### PR DESCRIPTION
@stefanv I am having trouble figuring out why the example text is being rendered:
![screenshot](https://user-images.githubusercontent.com/123428/154135280-bbfa81ee-efc2-4986-ad58-ecde05cf8a19.png)

- [ ] The example is rendered, but it is supposed to show the text.
- [ ] The text is also getting clipped in the rendered version.  I don't know when this started, but it used to not do this.  I know it worked correctly before we switched to scientific-python-hugo-theme, but I don't remember if it ever rendered correctly after we switched.