### PR TITLE
Switch to a FontAwesome 6 kit

### DIFF
--- a/doc/config.yaml
+++ b/doc/config.yaml
@@ -42,7 +42,8 @@ params:
     socialmediatitle: ""
     socialmedia:
       - link: https://github.com/scientific-python/
-        icon: github
+        # Find icon names here: https://fontawesome.com/search
+        icon: fa-brands fa-github
     quicklinks:
       column1:
         title: ""

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -34,7 +34,7 @@
             <div class="social-media-icons">
               {{- range $socialMedia }}
               <a class="level-item" href="{{ .link }}" aria-label="{{ .link }}">
-                <span class="icon"><i class="fab fa-{{ .icon }}"></i></span>
+                <span class="icon"><i class="{{ .icon }}"></i></span>
               </a>
               {{- end }}
             </div>

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -1,8 +1,7 @@
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="{{ "js/fresh.js" | relURL }}"></script>
 <!-- Font Awesome -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/js/all.min.js"></script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
+<script src="https://kit.fontawesome.com/472570992a.js" crossorigin="anonymous"></script>
 <!-- UIkit -->
 <script src="https://cdn.jsdelivr.net/npm/uikit@3.7.6/dist/js/uikit.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.7.6/dist/css/uikit.min.css" />


### PR DESCRIPTION
A kit is a personalized FA download. You need a FontAwesome account to
make one, but it's free: https://fontawesome.com/v6/docs/web/setup/use-kit

In order to accommodate all FA icons, icon names are now specified differently:

`fa-brands fa-github` instead of `github`

These names can be found at https://fontawesome.com/search

The kit download should be significantly smaller than what we had
before, with icons being downloaded on-demand.