### PR TITLE
Update hugo

### DIFF
--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -14,7 +14,7 @@
 
   # optional, fails build when a category is below a threshold
   [plugins.inputs.thresholds]
-    performance = 0.8
+    performance = 0.85
     accessibility = 0.95
     best-practices = 0.95
     seo = 0.95

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -4,7 +4,7 @@
 
 [build.environment]
   PYTHON_VERSION = "3.8"
-  HUGO_VERSION = "0.92.1"
+  HUGO_VERSION = "0.93.1"
 
 [[plugins]]
   package = "netlify-plugin-checklinks"


### PR DESCRIPTION
Lighthouse is reporting that there is a significant slow down (85 to 69) between Hugo 0.92 and 0.93.  I noticed it on blog.scientific-python.org first.

https://theme.scientific-python.org/reports/lighthouse

vs.

https://deploy-preview-125--scientific-python-hugo-theme.netlify.app/reports/lighthouse

It looks like it is loading some css twice.  For example,

- http://localhost:5000/css/scientific-python-hugo-theme/bulma.css
- http://localhost:5000/css/user/bulma.min.3f18e092bba58a868583ff35ca284cb12278073c0d8dee4f5281ddcb30ba88fe.css

It didn't seem to be loading from `css/user/` (just `css/scientific-python-hugo-theme`) before.

Also see https://github.com/scientific-python/scientific-python.org/pull/212.