### PR TITLE
Update Hugo

### DIFF
--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -4,7 +4,7 @@
 
 [build.environment]
   PYTHON_VERSION = "3.8"
-  HUGO_VERSION = "0.93.1"
+  HUGO_VERSION = "0.93.2"
 
 [[plugins]]
   package = "netlify-plugin-checklinks"


### PR DESCRIPTION
The theme works for 0.93.1 after #132, but it doesn't work for 0.93.2:
https://github.com/gohugoio/hugo/releases/tag/v0.93.2

```
7:55:56 AM: Start building sites …
7:55:56 AM: hugo v0.93.2-643B5AE9+extended linux/amd64 BuildDate=2022-03-04T12:21:49Z VendorInfo=gohugoio
7:55:56 AM: ERROR 2022/03/04 15:55:56 render of "section" failed: execute of template failed: template: _default/section.html:41:7: executing "_default/section.html" at <partial "javascript.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/javascript.html:17:11": execute of template failed: template: partials/javascript.html:17:11: executing "partials/javascript.html" at <readDir $jsDir>: error calling readDir: failed to read directory "static/js": open /opt/build/repo/doc/static/js: no such file or directory
7:55:56 AM: ERROR 2022/03/04 15:55:56 render of "page" failed: execute of template failed: template: _default/single.html:41:7: executing "_default/single.html" at <partial "javascript.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/javascript.html:17:11": execute of template failed: template: partials/javascript.html:17:11: executing "partials/javascript.html" at <readDir $jsDir>: error calling readDir: failed to read directory "static/js": open /opt/build/repo/doc/static/js: no such file or directory
7:55:56 AM: ERROR 2022/03/04 15:55:56 render of "page" failed: execute of template failed: template: _default/single.html:41:7: executing "_default/single.html" at <partial "javascript.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/javascript.html:17:11": execute of template failed: template: partials/javascript.html:17:11: executing "partials/javascript.html" at <readDir $jsDir>: error calling readDir: failed to read directory "static/js": open /opt/build/repo/doc/static/js: no such file or directory
7:55:56 AM: ERROR 2022/03/04 15:55:56 render of "page" failed: execute of template failed: template: _default/single.html:41:7: executing "_default/single.html" at <partial "javascript.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/javascript.html:17:11": execute of template failed: template: partials/javascript.html:17:11: executing "partials/javascript.html" at <readDir $jsDir>: error calling readDir: failed to read directory "static/js": open /opt/build/repo/doc/static/js: no such file or directory
7:55:56 AM: Error: Error building site: failed to render pages: render of "home" failed: execute of template failed: template: index.html:41:7: executing "index.html" at <partial "javascript.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/javascript.html:17:11": execute of template failed: template: partials/javascript.html:17:11: executing "partials/javascript.html" at <readDir $jsDir>: error calling readDir: failed to read directory "static/js": open /opt/build/repo/doc/static/js: no such file or directory
```

Out of curiousity, I checked (#135) whether the theme worked with 0.93.2 without the change from #132 and it doesn't:
```
8:01:06 AM: Start building sites …
8:01:06 AM: hugo v0.93.2-643B5AE9+extended linux/amd64 BuildDate=2022-03-04T12:21:49Z VendorInfo=gohugoio
8:01:06 AM: ERROR 2022/03/04 16:01:06 render of "section" failed: execute of template failed: template: _default/section.html:8:7: executing "_default/section.html" at <partial "css.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/css.html:48:11": execute of template failed: template: partials/css.html:48:11: executing "partials/css.html" at <readDir $cssDir>: error calling readDir: failed to read directory "assets/css": open /opt/build/repo/doc/assets/css: no such file or directory
8:01:06 AM: ERROR 2022/03/04 16:01:06 render of "page" failed: execute of template failed: template: _default/single.html:8:7: executing "_default/single.html" at <partial "css.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/css.html:48:11": execute of template failed: template: partials/css.html:48:11: executing "partials/css.html" at <readDir $cssDir>: error calling readDir: failed to read directory "assets/css": open /opt/build/repo/doc/assets/css: no such file or directory
8:01:06 AM: ERROR 2022/03/04 16:01:06 render of "page" failed: execute of template failed: template: _default/single.html:8:7: executing "_default/single.html" at <partial "css.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/css.html:48:11": execute of template failed: template: partials/css.html:48:11: executing "partials/css.html" at <readDir $cssDir>: error calling readDir: failed to read directory "assets/css": open /opt/build/repo/doc/assets/css: no such file or directory
8:01:06 AM: ERROR 2022/03/04 16:01:06 render of "page" failed: execute of template failed: template: _default/single.html:8:7: executing "_default/single.html" at <partial "css.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/css.html:48:11": execute of template failed: template: partials/css.html:48:11: executing "partials/css.html" at <readDir $cssDir>: error calling readDir: failed to read directory "assets/css": open /opt/build/repo/doc/assets/css: no such file or directory
8:01:06 AM: Error: Error building site: failed to render pages: render of "page" failed: execute of template failed: template: _default/single.html:8:7: executing "_default/single.html" at <partial "css.html" .>: error calling partial: "/opt/build/scientific-python-hugo-theme/layouts/partials/css.html:48:11": execute of template failed: template: partials/css.html:48:11: executing "partials/css.html" at <readDir $cssDir>: error calling readDir: failed to read directory "assets/css": open /opt/build/repo/doc/assets/css: no such file or directory
```