### PR TITLE
Only add news link if it exists

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,9 @@
     {{ partial "single/content.html" . }}
     {{ end }}
 
+    {{ if .Site.GetPage "/news" }}
     {{ partial "news.html" . }}
+    {{ end }}
 
     {{ if .Site.Params.keyfeatures }}
     {{ partial "keyfeatures.html" . }}


### PR DESCRIPTION
See https://github.com/scientific-python/learn.scientific-python.org/pull/2

The test commits are to verify that this works, but should be removed before this is merged.