### PR TITLE
Center footer elements

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -211,8 +211,12 @@ p {
 }
 
 .footer-column {
-    padding-left: 30px;
-    margin-top: 20px;
+    padding-left: 0px;
+    margin-top:20px
+}
+
+#footer-columns > div > div > ul {
+    padding-left: 0px;
 }
 
 .link-column {


### PR DESCRIPTION
When using small screens like a phone, the elements of the footer are not centred. This fixes it.