### PR TITLE
Modified footer logos

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -315,18 +315,23 @@ svg.icon {
 
 /* Icon size slightly enlargened for footer */
 #footer .social-media-icons {
-  font-size: 1.5em;
-}
-
-#footer svg.icon {
-  fill: #1e87f0;
-  margin-right: 0.5rem;
-}
+    font-size: 2.3em;
+  }
+  
+  #footer svg.icon {
+    fill: var(--colorSecondary);
+    margin-right: 0.5rem;
+  }
+  
+  #footer svg.icon:hover {
+      fill: #ffffff;
+  }
 
 /* For information ⓘ, when icon is missing */
 #footer .icon {
   font-weight: 900;
-  color: #1e87f0;
+  color: var(--colorSecondary);
+}
 
 .highlight {
     padding: 10px;


### PR DESCRIPTION
In accordance with issue #187 

and [issue #441](https://github.com/numpy/numpy.org/issues/441) of the [numpy.org](https://github.com/numpy/numpy.org) repository.

This PR solves this issue in this way - 

color - colorSecondary
color on hover - white(#fff)
size - 2.3em (which was previously 1.5em, anything greater than that seems too big and out of proportion)

![image](https://user-images.githubusercontent.com/77312781/177027270-318678be-1789-43f7-ab97-7bd2f49f713e.png)