### PR TITLE
MAINT: rename icons section to avoid adblock filtering

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -292,7 +292,7 @@ blockquote p {
     max-width: 50vw;
   }
 
-  .social-media-icons {
+  .community-icons {
     width: 100%;
   }
 }
@@ -308,12 +308,12 @@ svg.icon {
   width: 1.5rem;
 }
 
-#footer .social-media-icons {
+#footer .community-icons {
   /* Icon size slightly enlargened for footer */
   font-size: 2.3em;
 }
 
-#footer .social-media-icons a {
+#footer .community-icons a {
   display: inline-block;
 }
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -31,7 +31,7 @@
         <div class="footer-actions">
           {{ partial "footer_actions.html" . }}
           <nav class="level is-mobile">
-            <div class="social-media-icons">
+            <div class="community-icons">
               {{- range $socialMedia }}
               <a class="level-item" href="{{ .link }}" aria-label="{{ .link }}">
                 {{if .icon -}}


### PR DESCRIPTION
I couldn't fully test this locally as I was getting a make error, but I am almost certain this would fix the issue I see, namely that I don't see the community and social media icons in the footer.