### PR TITLE
Fix: (layouts/partials/footer.html) Alignment

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -52,11 +52,12 @@ em {
   font-weight: 900;
   font-size: 6em;
   color: var(--colorPrimaryDark);
+  margin: 0.5em;
 }
 
 .hero-logo {
   max-height: 75px;
-  padding: 0px 0 0 15px;
+  margin: 1em;
 }
 
 .hero-subtitle {

--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -182,21 +182,11 @@ p {
   .hero-title {
     font-size: 4em;
   }
-
-  .hero-logo {
-    max-height: 60px;
-  }
 }
 
 @media only screen and (max-width: 400px) {
-  .hero-logo {
-    max-height: 50px;
-  }
-}
-
-@media only screen and (max-width: 320px) {
-  .hero-logo {
-    max-height: 40px;
+  .hero-title {
+    flex-direction: column;
   }
 }
 

--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -33,12 +33,11 @@ em {
 }
 
 .hero-title-content {
+  align-items: center;
   display: flex;
   flex-direction: row;
-  width: 100%;
-  max-width: 1200px;
-  margin: 6vh auto;
   justify-content: space-around;
+  width: 100%;
 }
 
 .hero-headline {
@@ -47,17 +46,20 @@ em {
 }
 
 .hero-title {
+  align-content: center;
+  align-items: center;
   display: flex;
+  flex-direction: row;
   font-family: var(--fontFamily), sans-serif;
   font-weight: 900;
   font-size: 6em;
   color: var(--colorPrimaryDark);
-  margin: 0.5em;
+  padding: 0 0.5em 0.5em;
 }
 
 .hero-logo {
-  max-height: 75px;
-  margin: 1em;
+  max-height: 2em;
+  padding: 0.25em;
 }
 
 .hero-subtitle {
@@ -67,6 +69,9 @@ em {
 
 .hero-cta {
   padding: 15px 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-self: center;
 }
 
 .cta-button {

--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -340,3 +340,7 @@ svg.icon {
 .chroma {
   padding: 10px;
 }
+
+/* Local Variables: */
+/* css-indent-offset: 2 */
+/* End: */

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,7 +16,7 @@
           <div class="footer-column">
             <div class="footer-header">
             </div>
-            <ul class="link-list" style="padding-left: 30px; margin-top: 20px;">
+            <ul class="link-list" style="margin-top: 20px;">
               {{- range .links }}
               <li class="link-list">
                 <a class="footer-link" href="{{ .link }}">


### PR DESCRIPTION
This removes the hard-coded padding-left property from these UL elements.  It fixes the alignment in a narrow (e.g. smartphone) display, and in a wide (e.g. desktop) display, the difference is insignificant and no worse.

Fixes #192.  Thanks to Pamphile Roy (@tupui) for reporting.

### Screenshots

#### Before changes

![before-narrow](https://user-images.githubusercontent.com/601365/236990048-9dfeb7cf-e40d-4c9a-9452-47996a484a92.png)
![before-wide](https://user-images.githubusercontent.com/601365/236990073-bb5ce619-f7b2-4bf4-8d25-512993d5d04b.png)

#### After changes

![after-narrow](https://user-images.githubusercontent.com/601365/236990104-5e786237-468d-4d67-9778-6dce1e4accac.png)
![after-wide](https://user-images.githubusercontent.com/601365/236990129-f8fe7409-f3db-4b9f-97d3-7151cc398872.png)
