### PR TITLE
Meta: Add .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((css-mode . ((css-indent-offset . 2))))


### PR DESCRIPTION
To ensure Emacs indents CSS files consistently with the project's existing 2-spaces-per-level.  (This file will likely be useful for other file types as well.)