### PR TITLE
Let front-page button resize itself

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -75,16 +75,19 @@ em {
 }
 
 .cta-button {
-  width: 39em;
-  height: 3em;
-  font-size: 0.7em;
+  min-width: 15rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  width: auto;
+  height: 3rem;
+  font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 1.5px;
   font-weight: 500;
   color: var(--colorSecondaryLight);
   background-color: var(--colorPrimaryDark);
   border: none;
-  border-radius: 0.7em;
+  border-radius: 25px;
   outline: none;
   /* Black, with 10% opacity */
   box-shadow: 0px 8px 15px var(--colorShadow);

--- a/config.yaml
+++ b/config.yaml
@@ -9,3 +9,6 @@ params:
   plausible:
     dataDomain: null
     javaScript: "https://views.scientific-python.org/js/script.js"
+  hero:
+    buttontext: GitHub
+    buttonlink: https://github.com/scientific-python/scientific-python-hugo-theme


### PR DESCRIPTION
- The button will never be narrower than 15rem.
- The button now has padding 1.5rem on either side of the text.
- An example button has been added to the documentation, (arbitrarily) pointing to GitHub.