### PR TITLE
Center Hero content

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -36,7 +36,7 @@ em {
   align-items: center;
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
+  justify-content: center;
   width: 100%;
 }
 


### PR DESCRIPTION
This starts to address the problem where content tends to shift to the left for short Hero titles.  The solution is not complete, in that scaling is still a bit odd for certain screen widths, where there is a notable space between the logo and the hero title.