### PR TITLE
Fix: Margin, justification of logo

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -21,6 +21,7 @@ em {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  margin-left: 0.5em;
 }
 
 .hero-container {
@@ -54,7 +55,8 @@ em {
   font-weight: 900;
   font-size: 6em;
   color: var(--colorPrimaryDark);
-  padding: 0 0.5em 0.5em;
+  justify-content: center;
+  margin-right: 0.5em;
 }
 
 .hero-logo {


### PR DESCRIPTION
* assets/theme-css/styles.css:
(.flex-column): Add "margin-left: 0.5em;"
(.hero-title): Add "justify-content: center; margin-right: 0.5em;"

Intended to fix overlap issue shown by
<https://github.com/numpy/numpy.org/pull/668#issuecomment-1684350148>.