### PR TITLE
Fix: Spacing around notice boxes

### DIFF
--- a/assets/theme-css/notices.css
+++ b/assets/theme-css/notices.css
@@ -1,6 +1,6 @@
 .notice {
-  margin-top: 0rem;
-  margin-bottom: 0rem;
+  margin-top: 1em;
+  margin-bottom: 1em;
   color: #666;
 }
 

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -32,5 +32,5 @@ This is our values.
   <div class="notice-type">🛈  &nbsp;{{ .Get 0 | humanize }}</div>
   <div class="notice-content">
     {{ .Inner | markdownify }}
-  </div></br>
+  </div>
 </div>


### PR DESCRIPTION
* assets/theme-css/notices.css:
(.notice): Set top/bottom margins to 1em.

* layouts/shortcodes/notice.html: Remove `<br>`.

Fixes <https://github.com/scientific-python/scientific-python-hugo-theme/issues/254>.

After this change:
![notice-after](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/858d7a9d-28bb-4465-a3e0-6fa5338214cd)
