### PR TITLE
Meta: (.dir-locals.el) Set html-mode indentation default

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,5 @@
-;;; Directory Local Variables
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((css-mode . ((css-indent-offset . 2))))
+((css-mode . ((css-indent-offset . 2)))
+ (html-mode . ((sgml-basic-offset . 4))))


### PR DESCRIPTION
This makes Emacs respect the project's existing HTML indentation level by default.