### PR TITLE
Fix: Project icon positioning (#261)

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -56,12 +56,15 @@ em {
   font-size: 6em;
   color: var(--colorPrimaryDark);
   justify-content: center;
+  margin-bottom: 0.2em;
   margin-right: 0.5em;
 }
 
 .hero-logo {
-  max-height: 2em;
-  padding: 0.25em;
+  align-self: start;
+  margin: 0.1em;
+  margin-left: 0.25em;
+  max-height: 0.8em;
 }
 
 .hero-subtitle {


### PR DESCRIPTION
This moves the project icon to appear like a superscript.  See #261.

![Screen Shot 2023-09-25 at 22 00 16](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/9fc48c39-dc40-4ef2-87b5-13ffda3199d4)
