### PR TITLE
Fix: (.navbar-logo-text) Color

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -364,7 +364,7 @@ a.navbar-item:hover {
 }
 
 .navbar-logo-text {
-  color: var(--colorTextInverse);
+  color: var(--colorText);
   font-size: 1.25rem;
   font-weight: bold;
 }


### PR DESCRIPTION
Somehow this slipped by without my noticing it in the dark-mode PR:

<details><summary>Screenshots before/after</summary>
<p>

![localhost_1313_posts_](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/1fe85281-0a7d-4cd0-b4b7-e143cbbe054b)

![localhost_1313_posts_ (1)](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/0f629046-b013-4757-b536-3572f8a84b27)


</p>
</details> 