### PR TITLE
Blog dark theme issues

### DIFF
--- a/assets/theme-css/content.css
+++ b/assets/theme-css/content.css
@@ -1,7 +1,7 @@
 .content-padding {
   display: flex;
   justify-content: center;
-  padding: 75px 15px 125px 15px;
+  margin: 1em;
 }
 
 .content-container {

--- a/assets/theme-css/panel.css
+++ b/assets/theme-css/panel.css
@@ -49,12 +49,6 @@
   padding-top: 1em;
 }
 
-.panel-box-content:hover > .panel-box-text,
-.panel-box-content:focus > .panel-box-text,
-.panel-box-content:active > .panel-box-text {
-  color: var(--colorSecondaryDark);
-}
-
 @media only screen and (max-width: 1280px) {
   .panel .container {
     align-items: center;

--- a/assets/theme-css/panel.css
+++ b/assets/theme-css/panel.css
@@ -83,10 +83,6 @@
 .panel-underline {
   display: inline-block;
   vertical-align: middle;
-  -webkit-transform: perspective(1px) translateZ(0);
-  transform: perspective(1px) translateZ(0);
-  /* Black, with 10% opacity */
-  box-shadow: 0px 8px 15px var(--colorShadow);
   position: relative;
   overflow: hidden;
 }

--- a/assets/theme-css/panel.css
+++ b/assets/theme-css/panel.css
@@ -1,5 +1,5 @@
 .panel {
-  margin: 15px 0;
+  margin: 1em;
 }
 
 .panel .container {

--- a/assets/theme-css/panel.css
+++ b/assets/theme-css/panel.css
@@ -1,5 +1,7 @@
 .panel {
   margin: 1em;
+  /* Override bulma. */
+  box-shadow: none;
 }
 
 .panel .container {

--- a/assets/theme-css/panel.css
+++ b/assets/theme-css/panel.css
@@ -107,7 +107,7 @@
 .panel-button {
   border: 2px solid var(--colorPrimary);
   background-color: var(--colorLight);
-  color: var(--colorPrimary);
+  color: var(--colorText);
   font-size: 16px;
   cursor: pointer;
   padding-bottom: calc(0.5em - 1px);

--- a/assets/theme-css/panel.css
+++ b/assets/theme-css/panel.css
@@ -19,7 +19,7 @@
   height: 140px;
   min-width: 275px;
   width: 335px;
-  margin: 25px 15px 25px 15px;
+  margin: 0.5em 1em;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
In https://deploy-preview-137--blog-scientific-python-org.netlify.app/, we  have:
![2023-09-30T19:56:42,722402600-07:00](https://github.com/scientific-python/scientific-python-hugo-theme/assets/123428/8c0bca3c-b48f-4071-9809-721874369143)
and
![2023-09-30T19:57:03,000628949-07:00](https://github.com/scientific-python/scientific-python-hugo-theme/assets/123428/7d7cf822-8aec-4444-902f-bfe974a72c88)

They should probably be changed just like the key feature boxes.
