### PR TITLE
Use dart sass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ teams: | teams-clean $(patsubst %,$(TEAMS_DIR)/%.md,$(TEAMS))
 doc/content/shortcodes.md: $(wildcard layouts/shortcodes/*.html)
 	python tools/render_shortcode_docs.py > doc/content/shortcodes.md
 
-docs: doc/content/shortcodes.md
-	(cd doc ; hugo --themesDir="../..")
-
 # Serve for development purposes.
 doc-serve: doc/content/shortcodes.md
 	(cd doc && hugo --printI18nWarnings serve --themesDir="../.." --disableFastRender --poll 1000ms)
@@ -34,12 +31,14 @@ doc-serve: doc/content/shortcodes.md
 # The following is for use on netlify
 # -----------------------------------
 
-theme: doc/content/shortcodes.md scipy main blog learn
-	(cd doc ; hugo --themesDir="../..")
+netlify: theme scipy main blog learn
 	mv scipy/public doc/public/scipy
 	mv main/public doc/public/main
 	mv blog/public doc/public/blog
 	mv learn/public doc/public/learn
+
+theme: doc/content/shortcodes.md
+	(cd doc ; hugo --themesDir="../..")
 
 scipy:
 	rm -rf $@

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -2,14 +2,16 @@
   PYTHON_VERSION = "3.8" # netlify currently only support 2.7 and 3.8
   HUGO_VERSION = "0.119.0"
   DART_SASS_VERSION = "1.69.4"
+  DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 
 [build]
   base = "doc"
   publish = "public"
   command = """\
-    curl -LJO https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz && \
-    tar -xf dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz && \
-    rm dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz && \
+    export DART_SASS_TARBALL="dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz" && \
+    curl -LJO ${DART_SASS_URL}/${DART_SASS_VERSION}/${DART_SASS_TARBALL} && \
+    tar -xf ${DART_SASS_TARBALL} && \
+    rm ${DART_SASS_TARBALL} && \
     export PATH=/opt/build/repo/doc/dart-sass:$PATH && \
     (cd ../.. ; ln -s repo scientific-python-hugo-theme) && \
     (cd .. ; make docs) \

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -14,7 +14,7 @@
     rm ${DART_SASS_TARBALL} && \
     export PATH=/opt/build/repo/doc/dart-sass:$PATH && \
     (cd ../.. ; ln -s repo scientific-python-hugo-theme) && \
-    (cd .. ; make docs) \
+    (cd .. ; make theme) \
     """
 
 [context.deploy-preview]

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -1,6 +1,19 @@
 [build.environment]
   PYTHON_VERSION = "3.8" # netlify currently only support 2.7 and 3.8
   HUGO_VERSION = "0.119.0"
+  DART_SASS_VERSION = "1.69.4"
+
+[build]
+  base = "doc"
+  publish = "public"
+  command = """\
+    curl -LJO https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz && \
+    tar -xf dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz && \
+    rm dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz && \
+    export PATH=/opt/build/repo/doc/dart-sass:$PATH && \
+    (cd ../.. ; ln -s repo scientific-python-hugo-theme) && \
+    (cd .. ; make docs) \
+    """
 
 [context.deploy-preview]
   ignore = "false"

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -2,8 +2,10 @@
 {{- $page := . -}}
 
 {{- $inServerMode := .Site.IsServer -}}
+{{- $serverOpts   := cond ($inServerMode) (dict "enableSourceMap" true) (dict "outputStyle" "compressed") -}}
+{{- $sassCompiler := dict "transpiler" "dartsass" -}}
+{{- $cssOpts      := collections.Merge $sassCompiler $serverOpts -}}
 {{- $sass         := (slice "theme-css/fresh/core.scss") -}}
-{{- $cssOpts      := cond ($inServerMode) (dict "enableSourceMap" true) (dict "outputStyle" "compressed") -}}
 
 <!-- Fonts -->
 {{- $fontName     := .Site.Params.font.name | default "Open Sans" -}}


### PR DESCRIPTION
See https://sass-lang.com/blog/libsass-is-deprecated/ and https://gohugo.io/hugo-pipes/transpile-sass-to-css/#dart-sass.

We will need to update the various sites and then we can make a new PR to change this line in the netlify.toml file.
```
    (cd .. ; make docs) \
```
to
```
    (cd .. ; make theme) \
```

We will also need to add documentation for the INSTALL, but we can do that in the PR that fixes the netlify.toml file.