### PR TITLE
Disable taxonomy index page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,5 @@
+disableKinds:
+  - taxonomy
 params:
   fadeFrontPage: false
   images:


### PR DESCRIPTION
We do not currently provide a layout for the taxonomy index page. That can be changed by adding `layouts/_default/taxonomy.html`

See
- https://gohugo.io/content-management/taxonomies/#default-taxonomies
- https://gohugo.io/templates/lookup-order/

Closes #314