### PR TITLE
Do not render duplicate shortcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ teams-clean:
 teams: | teams-clean $(patsubst %,$(TEAMS_DIR)/%.md,$(TEAMS))
 
 doc/content/shortcodes.md: $(wildcard layouts/shortcodes/*.html)
-	python tools/render_shortcode_docs.py > doc/content/shortcodes.md
+	(cd layouts && python ../tools/render_shortcode_docs.py > ../doc/content/shortcodes.md)
 
 # Serve for development purposes.
 doc-serve: doc/content/shortcodes.md

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -18,12 +18,13 @@
   publish = "public"
   command = """\
     export DART_SASS_TARBALL="dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz" && \
-    curl -LJO ${DART_SASS_URL}/${DART_SASS_VERSION}/${DART_SASS_TARBALL} && \
-    tar -xf ${DART_SASS_TARBALL} && \
-    rm ${DART_SASS_TARBALL} && \
-    export PATH=/opt/build/repo/doc/dart-sass:$PATH && \
-    (cd ../.. ; ln -s repo scientific-python-hugo-theme) && \
-    (cd .. ; make ${BUILD_TARGET}) \
+    (cd /tmp && \
+     curl -LJO ${DART_SASS_URL}/${DART_SASS_VERSION}/${DART_SASS_TARBALL} && \
+     tar -xf ${DART_SASS_TARBALL} && \
+     rm ${DART_SASS_TARBALL}) && \
+    export PATH=/tmp/dart-sass:$PATH && \
+    (cd ../.. && ln -s repo scientific-python-hugo-theme) && \
+    (cd .. && make ${BUILD_TARGET})
     """
 
 [[plugins]]


### PR DESCRIPTION
Avoid picking up shortcodes outside of theme site

We change into the theme layout directory to prevent picking up
shortcodes from other checked-out repositories during the multi-site build.