### PR TITLE
Add date generated as comment

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
   <head>
+    {{ print "<!-- Generated " (time.Now.UTC.Format "2006-01-02 15:04:05 UTC") " -->" | safeHTML }}
     {{ partial "meta.html" . }}
     <title>{{ block "title" . }}{{ .Site.Title }}{{ if not (eq .Site.Title .Title) }} - {{ .Title }}{{end}}{{ end }}</title>
 


### PR DESCRIPTION
Strangely, there seems to be no official meta field for providing the last generated date.

This information is useful in debugging; e.g., to know whether CI deployed at an expected time or not.

Closes #307