### PR TITLE
Remove unused fadeFrontPage

### DIFF
--- a/assets/js/fresh.js
+++ b/assets/js/fresh.js
@@ -1,11 +1,3 @@
-//Preloader
-$(window).on("load", function () {
-  // makes sure the whole site is loaded
-  $("#status").fadeOut(); // will first fade out the loading animation
-  $("#preloader").delay(350).fadeOut("slow"); // will fade out the white DIV that covers the website.
-  $("body").delay(350).css({ overflow: "visible" });
-});
-
 $(document).ready(function () {
   //Mobile menu toggle
   if ($(".navbar-burger").length) {

--- a/assets/theme-css/fresh.css
+++ b/assets/theme-css/fresh.css
@@ -156,15 +156,6 @@ button:focus,
 button:active {
   outline: none;
 }
-#preloader {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #fff;
-  z-index: 99;
-}
 #status {
   width: 200px;
   height: 200px;

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,6 @@
 disableKinds:
   - taxonomy
 params:
-  fadeFrontPage: false
   images:
     - /images/logo.svg
   navColor: blue

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,11 +23,6 @@
 
   </head>
   <body>
-    <!-- Preloader. Set to true for front-page fade-in animation -->
-    {{ if (and .IsHome .Site.Params.fadeFrontPage) }}
-    <div id="preloader"></div>
-    {{ end -}}
-
     {{ block "navbar" . }}
     {{ partial "navbar.html" . -}}
     {{ partial "navbar-clone.html" . -}}


### PR DESCRIPTION
```
[jarrod@x111 hugo]$ grep -r 'fadeFrontPage: false'
scipy.org/themes/scientific-python-hugo-theme/config.yaml:  fadeFrontPage: false
numpy.org/themes/scientific-python-hugo-theme/config.yaml:  fadeFrontPage: false
scientific-python.org/themes/scientific-python-hugo-theme/config.yaml:  fadeFrontPage: false
blog.scientific-python.org/themes/scientific-python-hugo-theme/config.yaml:  fadeFrontPage: false
learn.scientific-python.org/themes/scientific-python-hugo-theme/config.yaml:  fadeFrontPage: false
tools.scientific-python.org/themes/scientific-python-hugo-theme/config.yaml:  fadeFrontPage: false
```