### PR TITLE
Improve blog post metadata rendering

### DIFF
--- a/assets/theme-css/posts.css
+++ b/assets/theme-css/posts.css
@@ -7,6 +7,10 @@ div.post-list {
   color: var(--pst-color-text-base) !important;
 }
 
+.post-meta {
+  color: var(--colorSecondaryDark);
+}
+
 .post-list article {
   padding-top: 1.5rem;
 }
@@ -17,7 +21,6 @@ div.post-list {
 }
 
 .post-author {
-  color: var(--colorSecondaryDark);
   display: inline;
 }
 
@@ -25,8 +28,8 @@ div.post-list {
   content: ", ";
 }
 
-.post-list .post-date {
-  color: var(--colorSecondaryDark);
+.post-date {
+  padding-left: 0.5rem;
 }
 
 .post-list .post-summary {

--- a/doc/config.yaml
+++ b/doc/config.yaml
@@ -3,7 +3,7 @@ languageCode: "en-us"
 title: "Scientific Python Hugo Theme documentation"
 theme: scientific-python-hugo-theme
 relativeURLs: true
-disableKinds: ["term", "taxonomy"]
+disableKinds: ["taxonomy"]
 
 markup:
   highlight:

--- a/layouts/partials/posts/meta.html
+++ b/layouts/partials/posts/meta.html
@@ -1,15 +1,15 @@
 <div class="post-meta">
   <span class="post-authors">
     {{- range .Params.author -}}
-    <div class="post-author">{{ partial "svg-icon" "person" }} {{ . }}</div>
+    <div class="post-author"><i class="fa-solid fa-user"></i> {{ . }}</div>
     {{- end -}}
   </span>
   {{ if .Date }}
-  <span class="post-date">{{ partial "svg-icon" "calendar" }} {{.Date.Format "January 2, 2006"}}</span>
+  <span class="post-date"><i class="fa-regular fa-calendar"></i> {{.Date.Format "January 2, 2006"}}</span>
   {{ end }}
   {{- if .Params.tags -}}
   <div class="post-tags">
-    {{ partial "svg-icon" "tag" }}
+    <i class="fa-solid fa-tag"></i>
     {{- range .Params.tags -}}
     {{- $tag := lower . }}
     <span class="post-tag"><a href="{{ path.Join "/tags/" $tag | relURL }}">#{{ $tag }}</a></span>


### PR DESCRIPTION
- Use secondary dark for all text
- Use FontAwesome instead of custom SVG icons
- Render tag pages by enabling page kind `term`