### PR TITLE
Add: "More" links after post summaries

### DIFF
--- a/assets/theme-css/posts.css
+++ b/assets/theme-css/posts.css
@@ -86,8 +86,6 @@ div.MathJax_Display {
 }
 
 .read-more {
-  margin-top: 0.5em;
-  font-variant-caps: small-caps;
   font-style: italic;
 }
 

--- a/assets/theme-css/posts.css
+++ b/assets/theme-css/posts.css
@@ -85,6 +85,12 @@ div.MathJax_Display {
   margin: 0.5em;
 }
 
+.read-more {
+  margin-top: 0.5em;
+  font-variant-caps: small-caps;
+  font-style: italic;
+}
+
 .tag-cloud {
   position: sticky;
   align-self: flex-start;

--- a/layouts/partials/posts/summary.html
+++ b/layouts/partials/posts/summary.html
@@ -4,7 +4,7 @@
   <img src="{{ .RelPermalink }}" {{ if .Params.description }}alt="{{ .Params.description }}"{{ end }}/>
   {{ end }}
   {{ strings.Chomp .Summary }}
-  <div class="read-more">
-      <a href="{{ .RelPermalink }}">more ⟶</a>
-  </div>
+  <span class="read-more">
+      <a href="{{ .RelPermalink }}">Read more...</a>
+  </span>
 </div>

--- a/layouts/partials/posts/summary.html
+++ b/layouts/partials/posts/summary.html
@@ -3,5 +3,8 @@
   {{ with $featuredImage }}
   <img src="{{ .RelPermalink }}" {{ if .Params.description }}alt="{{ .Params.description }}"{{ end }}/>
   {{ end }}
-  {{ .Summary }}
+  {{ strings.Chomp .Summary }}
+  <div class="read-more">
+      <a href="{{ .RelPermalink }}">more ⟶</a>
+  </div>
 </div>


### PR DESCRIPTION
After exploring a number of variants ("Read more" vs. "more", arrow vs. ellipsis, left-align vs. right-aligned, in a separate paragraph vs. immediately after the summary text, italic vs. normal, small-caps variants and non-, etc.), I settled on this.

I think it would look even better (less cluttered) were it not underlined, but which links to underline is probably a wider discussion that needs to be had (or one that has been had that I'm just not aware of).

Please let me know if you'd like me to make more changes.  Thanks.

Visible at: https://deploy-preview-391--scientific-python-hugo-theme.netlify.app/blog/