### PR TITLE
Do not escape heading anchors unnecessarily

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,3 @@
-<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}<a class="headerlink" href="#{{ .Anchor | safeURL }}" title="Link to this heading">#</a></h{{ .Level }}>
+{{ $id := .Anchor | anchorize -}}
+{{- $anchor := printf "#%s" $id -}}
+<h{{ .Level }} id="{{ $id }}">{{ .Text | safeHTML }}<a class="headerlink" {{ printf "href=%q" $anchor | safeHTMLAttr }} title="Link to this heading">#</a></h{{ .Level }}>


### PR DESCRIPTION
See https://discourse.gohugo.io/t/are-headings-rendered-through-render-heading-html-post-processed/47018