### PR TITLE
Fix: (posts, shortcuts) Adjust width, padding for narrower screens

### DIFF
--- a/assets/theme-css/content.css
+++ b/assets/theme-css/content.css
@@ -1,38 +1,21 @@
-/* Default: single column layout for mobile */
-.content-container {
-  max-width: 70em;
-  margin: 0 30px;
-  flex-direction: column;
-}
-
-/* Full screen two-column layout for desktop etc. */
-@media only screen and (min-width: 75em) {
-  .content-container {
-    flex-basis: 70em;
-    flex-direction: row;
-  }
-
-  article {
-    flex-grow: 1;
-    flex-shrink: 0;
-    flex-basis: calc(50% - 1rem);
-  }
-}
-
-/* Other rules. */
-
 .content-padding {
   display: flex;
+  flex-wrap: nowrap;
   justify-content: center;
   margin: 1em;
 }
 
-.content-container .divider {
-  height: 3px;
-  border-radius: 50px;
-  background: var(--pst-color-text-base);
-  width: 60px;
-  &.is-centered {
-    margin: 0 auto;
+.content-container {
+  max-width: 70em;
+  flex-basis: 70em;
+  flex-shrink: 1;
+  margin: 0 30px;
+  flex-direction: column;
+}
+
+/* Start wrapping at the same breakpoint as the one that enables the burger menu */
+@media screen and (max-width: 1023px) {
+  .content-padding {
+    flex-wrap: wrap;
   }
 }

--- a/assets/theme-css/content.css
+++ b/assets/theme-css/content.css
@@ -8,7 +8,7 @@
 /* Full screen two-column layout for desktop etc. */
 @media only screen and (min-width: 75em) {
   .content-container {
-    min-width: 70rem;
+    flex-basis: 70em;
     flex-direction: row;
   }
 

--- a/assets/theme-css/content.css
+++ b/assets/theme-css/content.css
@@ -6,16 +6,11 @@
 }
 
 .content-container {
-  max-width: 70em;
   flex-basis: 70em;
   flex-shrink: 1;
-  margin: 0 30px;
   flex-direction: column;
-}
+  margin: 0 30px;
 
-/* Start wrapping at the same breakpoint as the one that enables the burger menu */
-@media screen and (max-width: 1023px) {
-  .content-padding {
-    flex-wrap: wrap;
-  }
+  /* Handle code cells overflowing */
+  overflow: auto;
 }

--- a/assets/theme-css/content.css
+++ b/assets/theme-css/content.css
@@ -1,13 +1,30 @@
+/* Default: single column layout for mobile */
+.content-container {
+  max-width: 70em;
+  margin: 0 30px;
+  flex-direction: column;
+}
+
+/* Full screen two-column layout for desktop etc. */
+@media only screen and (min-width: 75em) {
+  .content-container {
+    min-width: 70rem;
+    flex-direction: row;
+  }
+
+  article {
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: calc(50% - 1rem);
+  }
+}
+
+/* Other rules. */
+
 .content-padding {
   display: flex;
   justify-content: center;
   margin: 1em;
-}
-
-.content-container {
-  max-width: 850px;
-  margin: 0 30px;
-  overflow: hidden;
 }
 
 .content-container .divider {

--- a/assets/theme-css/posts.css
+++ b/assets/theme-css/posts.css
@@ -109,24 +109,3 @@ div.MathJax_Display {
   flex-wrap: wrap;
   column-gap: 2rem;
 }
-
-/* Default: single column layout for mobile */
-.content-container {
-  max-width: 70em;
-  margin: 0 30px;
-  flex-direction: column;
-}
-
-/* Full screen two-column layout for desktop etc. */
-@media only screen and (min-width: 75em) {
-  .content-container {
-    min-width: 70rem;
-    flex-direction: row;
-  }
-
-  article {
-    flex-grow: 1;
-    flex-shrink: 0;
-    flex-basis: calc(50% - 1rem);
-  }
-}

--- a/assets/theme-css/posts.css
+++ b/assets/theme-css/posts.css
@@ -1,5 +1,13 @@
-div.post-list {
-  clear: left;
+.post-list {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 2rem;
+}
+
+.post-list article {
+  flex-grow: 2;
+  flex-basis: 48%;
+  padding-top: 1.5rem;
 }
 
 .post-title a {
@@ -9,10 +17,6 @@ div.post-list {
 
 .post-meta {
   color: var(--pst-color-text-muted);
-}
-
-.post-list article {
-  padding-top: 1.5rem;
 }
 
 .post-list .post-title {
@@ -79,10 +83,11 @@ div.MathJax_Display {
 
 .post-featuredImage img {
   /* FIXME: Use color variable. */
-  border: 0.15em #bbb solid;
-  border-radius: 25px;
+  border: 1px #bbb solid;
   max-width: 20rem;
   margin: 0.5em;
+  float: left;
+  margin-right: 1.25rem;
 }
 
 .read-more {
@@ -102,10 +107,4 @@ div.MathJax_Display {
   font-size: 32px;
   margin-top: 60px;
   padding-bottom: 10px;
-}
-
-.content-container .post-list {
-  display: flex;
-  flex-wrap: wrap;
-  column-gap: 2rem;
 }

--- a/assets/theme-css/pst/base/_base.scss
+++ b/assets/theme-css/pst/base/_base.scss
@@ -160,11 +160,6 @@ pre {
   border: 1px solid var(--pst-color-border);
   border-radius: $admonition-border-radius;
 
-  // Prevent long, monospaced lines and words in PRE elements from
-  // breaking page layout.  Very non-obvious problem and solution.
-  white-space: pre-wrap;
-  word-break: break-all;
-
   .linenos {
     // minimum opacity to make the line numbers WCAG AA conformant
     opacity: 0.8;

--- a/assets/theme-css/pst/base/_base.scss
+++ b/assets/theme-css/pst/base/_base.scss
@@ -160,6 +160,11 @@ pre {
   border: 1px solid var(--pst-color-border);
   border-radius: $admonition-border-radius;
 
+  // Prevent long, monospaced lines and words in PRE elements from
+  // breaking page layout.  Very non-obvious problem and solution.
+  white-space: pre-wrap;
+  word-break: break-all;
+
   .linenos {
     // minimum opacity to make the line numbers WCAG AA conformant
     opacity: 0.8;

--- a/assets/theme-css/shortcuts.css
+++ b/assets/theme-css/shortcuts.css
@@ -49,8 +49,8 @@
   cursor: pointer;
 }
 
-/* FIXME: Should we specify this max-width in ems? */
-@media only screen and (max-width: 1090px) {
+/* Same breakpoint as burger menu */
+@media screen and (max-width: 1023px) {
   #shortcuts-container {
     display: none;
   }

--- a/assets/theme-css/shortcuts.css
+++ b/assets/theme-css/shortcuts.css
@@ -2,8 +2,11 @@
   position: sticky;
   align-self: flex-start;
   top: 5rem;
-  width: 100%;
-  max-width: 150px;
+  flex-basis: 15em;
+  /* We disable shrinking for this container, otherwise the single-line
+   items start wrapping to two lines, especially when active and
+   bolded, which causes distracting layout changes. */
+  flex-shrink: 0;
 }
 
 #shortcuts {

--- a/assets/theme-css/shortcuts.css
+++ b/assets/theme-css/shortcuts.css
@@ -46,6 +46,7 @@
   cursor: pointer;
 }
 
+/* FIXME: Should we specify this max-width in ems? */
 @media only screen and (max-width: 1090px) {
   #shortcuts-container {
     display: none;

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<section class="section content-padding flex-row">
+<section class="section content-padding">
   <div class="content-container">
     {{ partial "breadcrumbs.html" . }}
     <h1>{{ .Title }}</h1>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<section class="article content-padding flex-row">
+<section class="article content-padding">
   <div class="content-container">
     {{ partial "breadcrumbs.html" . }}
     <h1>{{ .Title }}</h1>

--- a/layouts/partials/posts/list.html
+++ b/layouts/partials/posts/list.html
@@ -1,4 +1,4 @@
-<section class="section content-padding flex-row">
+<section class="section content-padding">
   <div class="tag-cloud is-hidden-mobile">
     <h2 class="tag-cloud-title">{{ i18n "tags" }}</h2>
     {{ if not (eq (len $.Site.Taxonomies.tags) 0) }}

--- a/layouts/partials/posts/post.html
+++ b/layouts/partials/posts/post.html
@@ -9,7 +9,9 @@
     <div class="post-meta">{{ partial "posts/meta.html" . }}</div>
     <div class="post-content">
       {{ with $featuredImage }}
-      <img src="{{ .RelPermalink }}" {{ if .Params.description }}alt="{{ .Params.description }}"{{ end }}/>
+      <div class="post-featuredImage">
+        <img src="{{ .RelPermalink }}" {{ if .Params.description }}alt="{{ .Params.description }}"{{ end }}/>
+      </div>
       {{ end }}
       {{ .Content }}
     </div>

--- a/layouts/partials/posts/post.html
+++ b/layouts/partials/posts/post.html
@@ -1,5 +1,5 @@
 {{- $featuredImage := .Resources.GetMatch "featuredImage" -}}
-<section class="post content-padding flex-row">
+<section class="post content-padding">
   <div class="content-container">
     {{ partial "breadcrumbs.html" . }}
     <h1>{{ .Title }}</h1>

--- a/layouts/partials/section/section.html
+++ b/layouts/partials/section/section.html
@@ -1,4 +1,4 @@
-<section class="content-padding flex-row">
+<section class="content-padding">
 <div class="content-container">
   {{ partial "breadcrumbs.html" . }}
   <h1>{{ .Title }}</h1>


### PR DESCRIPTION
This prevents the main content container from being directly against
the edge of the screen or being pushed off-screen, and prevents the
shortcuts container from being too narrow.

<details><summary>Screenshots</summary>
<p>

![before](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/e48e5361-b575-4281-9867-a60b3f5d1426)
![after](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/74d9b285-bb95-4f24-a441-06788901cae5)

</p>
</details> 