### PR TITLE
Docs: Add tabs shortcode example

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -270,10 +270,6 @@ a.headerlink {
   visibility: visible;
 }
 
-/* Local Variables: */
-/* css-indent-offset: 2 */
-/* End: */
-
 #breadcrumbs {
   margin: 0;
   padding: 0;
@@ -284,3 +280,7 @@ a.headerlink {
   font-style: italic;
   margin-top: -0.5rem;
 }
+
+/* Local Variables: */
+/* css-indent-offset: 2 */
+/* End: */

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,3 +1,32 @@
+{{/*
+
+doc: A tabs panel.
+
+{{< tabs >}}
+
+{{< tab "c++" >}}
+An example program in C++:
+```c++
+int main(const int argc, const char **argv) {
+    return 0;
+}
+```
+It simply returns 0, indicating no errors.
+{{< /tab >}}
+
+{{< tab "python" >}}
+An example program in Python:
+```python
+def main():
+    return True
+```
+It returns `True`, indicating no errors.
+{{< /tab >}}
+
+{{< /tabs >}}
+
+*/}}
+
 <!-- Render inner tabs, which adds them to a scratch variable for this parent shortcode -->
 {{- .Inner -}}
 {{- $groupId := .Page.Scratch.Get "tabgroup" | default 0 -}}

--- a/tools/render_shortcode_docs.py
+++ b/tools/render_shortcode_docs.py
@@ -65,7 +65,9 @@ for shortcode_fn in shortcodes:
     print(f"## `{title}`")
     print()
     print(description)
-    print(f"```\n{example}\n```")
+    # We use an extra backtick here so code blocks embedded in the
+    # examples work correctly.
+    print(f"````\n{example}\n````")
     print("This example renders as:")
     print("___")
     print(code)


### PR DESCRIPTION
See <https://github.com/scientific-python/scientific-python-hugo-theme/issues/397>.

This also adds a `shortcode-example` shortcode, only used in our documentation, which distinguishes the rendered shortcode examples from the content in the page describing them.

It also fixes a small bug (encountered when adding the tabs shortcode example) regarding nested Markdown code blocks in the generated documentation.