### PR TITLE
Docs: Add toctree shortcode docs and render option in the Python script

### DIFF
--- a/layouts/shortcodes/toctree.html
+++ b/layouts/shortcodes/toctree.html
@@ -1,3 +1,13 @@
+{{/*
+
+options: {"render": False}
+
+doc: Shows a table-of-contents tree for the Hugo [`Sections`](https://gohugo.io/methods/page/sections/) in the current hierarchy.  In this documentaion, an example of the `toctree` is seen on the [Examples]({{% relref "examples" %}}) page.
+
+{{< toctree >}}
+
+*/}}
+
 <div class="toctree-wrapper">
   {{- range $section := .Page.Sections }}
   <ul>

--- a/tools/render_shortcode_docs.py
+++ b/tools/render_shortcode_docs.py
@@ -52,11 +52,13 @@ def shortcode_doc(fn):
     )
 
     # Process rendering options.
-    options_match = re.match("^{{/\\*.*^options: +({[^\n]+}) *$.*\\*/}}$", data,
-                             re.MULTILINE | re.DOTALL)
+    options_match = re.match(
+        "^{{/\\*.*^options: +({[^\n]+}) *$.*\\*/}}$", data, re.MULTILINE | re.DOTALL
+    )
     if options_match:
         # Read Python dict of options.
         from ast import literal_eval
+
         options = literal_eval(options_match.group(1))  # Safely read expression.
         assert isinstance(options, dict)
 


### PR DESCRIPTION
See <https://github.com/scientific-python/scientific-python-hugo-theme/issues/397>.