### PR TITLE
Fix: (styles.css) .navbar-menu colors

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -220,6 +220,12 @@ nav,
 .navbar-menu.is-active {
   background: var(--pst-color-text-muted);
 }
+.navbar-menu.is-active .navbar-item {
+    color: var(--pst-color-background);
+}
+.navbar-menu.is-active .navbar-item:hover {
+    color: var(--pst-color-link-hover);
+}
 
 a.navbar-item,
 a.navbar-item:visited {


### PR DESCRIPTION
When the navbar menu is collapsed into the hamburger menu, the text
color had poor contrast against the background.  Now it's clearly
readable.

It may also be desirable to change the hover background color, but
that can be considered separately.

<details><summary>Screenshots</summary>
<p>

![localhost_1313_shortcodes_](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/e4b64a9c-3c9b-4878-a96f-7bd8fc9d7627)
![localhost_1313_shortcodes_ (1)](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/547094c8-8f0b-4880-916c-19e2d57bd5dc)


</p>
</details> 