### PR TITLE
Allow sites to use local Sass files

### DIFF
--- a/assets/theme-css/fresh.css
+++ b/assets/theme-css/fresh.css
@@ -63,7 +63,7 @@
   position: absolute;
   left: 50%;
   top: 50%;
-  background-image: url(../../images/loaders/rings.svg);
+  background-image: url(../images/loaders/rings.svg);
   background-size: 80px 80px;
   background-repeat: no-repeat;
   background-position: 50%;

--- a/doc/content/getstarted.md
+++ b/doc/content/getstarted.md
@@ -75,7 +75,7 @@ Example `config.yaml` files can be seen in [scientific-python.org](https://githu
 To customize styles, add CSS (`.css`) and Sass (`.scss`) files to the `./assets/css/` directory.
 It's recommended to put your customizations in a file named `custom.css`, but other `.css` and `.scss` files added there will also be loaded.
 
-CSS files are compiled as Hugo templates, i.e. configuration variables from the `config.yaml` file can be accessed as `{{ .Site.Params.VARIABLE }}`.
+CSS and SCSS files are compiled as Hugo templates, i.e. configuration variables from the `config.yaml` file can be accessed as `{{ .Site.Params.VARIABLE }}`.
 
 ### JavaScript
 

--- a/doc/content/getstarted.md
+++ b/doc/content/getstarted.md
@@ -72,8 +72,8 @@ Example `config.yaml` files can be seen in [scientific-python.org](https://githu
 
 ### CSS
 
-To customize styles, add CSS and Sass files to the `./assets/css/` directory.
-It's recommended to put your customizations in a file named `custom.css`, but other `css` and `scss` files added there will also be loaded.
+To customize styles, add CSS (`.css`) and Sass (`.scss`) files to the `./assets/css/` directory.
+It's recommended to put your customizations in a file named `custom.css`, but other `.css` and `.scss` files added there will also be loaded.
 
 CSS files are compiled as Hugo templates, i.e. configuration variables from the `config.yaml` file can be accessed as `{{ .Site.Params.VARIABLE }}`.
 

--- a/doc/content/getstarted.md
+++ b/doc/content/getstarted.md
@@ -72,8 +72,8 @@ Example `config.yaml` files can be seen in [scientific-python.org](https://githu
 
 ### CSS
 
-To customize styles, add CSS files to the `./assets/css/` directory.
-It's recommended to put your customizations in a file named `custom.css`, but other `css` files added there will also be loaded.
+To customize styles, add CSS and Sass files to the `./assets/css/` directory.
+It's recommended to put your customizations in a file named `custom.css`, but other `css` and `scss` files added there will also be loaded.
 
 CSS files are compiled as Hugo templates, i.e. configuration variables from the `config.yaml` file can be accessed as `{{ .Site.Params.VARIABLE }}`.
 

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -5,7 +5,6 @@
 {{- $serverOpts := cond ($inServerMode) (dict "enableSourceMap" true) (dict "outputStyle" "compressed") -}}
 {{- $sassCompiler := dict "transpiler" "dartsass" -}}
 {{- $cssOpts := collections.Merge $sassCompiler $serverOpts -}}
-{{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss") | append (resources.Match "css/*.scss") -}}
 
 <!-- Fonts -->
 {{- $fontName := .Site.Params.font.name | default "Open Sans" -}}
@@ -13,7 +12,7 @@
 {{- $fontSizes := delimit (.Site.Params.font.sizes | default (slice 300 400 600 700)) ";" -}}
 {{- $fontUrl := printf "https://fonts.googleapis.com/css2?family=%s:wght@%s" $fontFace $fontSizes -}}
 
-<link rel="icon" href="{{ "images/favicon.ico" | relURL }}" />
+<link rel="icon" href="{{ " images/favicon.ico" | relURL }}" />
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -23,13 +22,16 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols+2">
 
 <!-- SASS -->
+{{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss") | append (resources.Match "css/*.scss") -}}
 {{- range $sass -}}
 
+{{- $targetFile := printf "%s.scss" . -}}
+
 {{- if $inServerMode -}}
-{{ $css := resources.Get . | toCSS $cssOpts -}}
+{{ $css := resources.Get . | resources.ExecuteAsTemplate $targetFile $page | toCSS $cssOpts -}}
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}">
 {{ else }}
-{{ $css := resources.Get . | toCSS $cssOpts | minify | fingerprint -}}
+{{ $css := resources.Get . | resources.ExecuteAsTemplate $targetFile $page | toCSS $cssOpts | minify | fingerprint -}}
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
 {{- end -}}
 
@@ -41,13 +43,11 @@
 
 {{- range $cssFiles -}}
 
-{{- $targetFile := printf "css/%s" . -}}
-
 {{ if $inServerMode -}}
-{{ $custom_style := . | resources.ExecuteAsTemplate $targetFile $page -}}
+{{ $custom_style := . | resources.ExecuteAsTemplate . $page -}}
 <link rel="stylesheet" href="{{ $custom_style.RelPermalink }}">
 {{ else }}
-{{ $custom_style := . | resources.ExecuteAsTemplate $targetFile $page | minify | fingerprint -}}
+{{ $custom_style := . | resources.ExecuteAsTemplate . $page | minify | fingerprint -}}
 <link rel="stylesheet" href="{{ $custom_style.RelPermalink }}" integrity="{{ $custom_style.Data.Integrity }}">
 {{- end -}}
 

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -5,7 +5,7 @@
 {{- $serverOpts := cond ($inServerMode) (dict "enableSourceMap" true) (dict "outputStyle" "compressed") -}}
 {{- $sassCompiler := dict "transpiler" "dartsass" -}}
 {{- $cssOpts := collections.Merge $sassCompiler $serverOpts -}}
-{{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss") -}}
+{{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss") | append (resources.Match "css/*.scss") -}}
 
 <!-- Fonts -->
 {{- $fontName := .Site.Params.font.name | default "Open Sans" -}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -12,7 +12,7 @@
 {{- $fontSizes := delimit (.Site.Params.font.sizes | default (slice 300 400 600 700)) ";" -}}
 {{- $fontUrl := printf "https://fonts.googleapis.com/css2?family=%s:wght@%s" $fontFace $fontSizes -}}
 
-<link rel="icon" href="{{ " images/favicon.ico" | relURL }}" />
+<link rel="icon" href="{{ "images/favicon.ico" | relURL }}" />
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
This processes ".scss" files in the "assets/css" directory, allowing
downstream sites to use Sass as well as plain CSS.