### PR TITLE
Add copy button for code blocks

### DIFF
--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -20,9 +20,8 @@ function add_button_to(element) {
 }
 
 function copy_content_of(event) {
-    // Omit "Copy" prefix from the button itself.
-    target = this.parentElement.textContent.substring(4);
-    navigator.clipboard.writeText(target)
+    content = this.parentElement.parentElement.textContent;
+    navigator.clipboard.writeText(content)
         .then(() => update_button(this));
 }
 

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -11,26 +11,25 @@ const pre_selector = "div.highlight pre";
 document.querySelectorAll(pre_selector).forEach(add_button_to);
 
 function add_button_to(element) {
-    div = document.createElement("div");
-    button = document.createElement("button");
-    div.classList.add("copy-button");
-    button.addEventListener("click", copy_content_of);
-    div.append(button);
-    element.prepend(div);
+  div = document.createElement("div");
+  button = document.createElement("button");
+  div.classList.add("copy-button");
+  button.addEventListener("click", copy_content_of);
+  div.append(button);
+  element.prepend(div);
 }
 
 function copy_content_of(event) {
-    content = this.parentElement.parentElement.textContent;
-    navigator.clipboard.writeText(content)
-        .then(() => update_button(this));
+  content = this.parentElement.parentElement.textContent;
+  navigator.clipboard.writeText(content).then(() => update_button(this));
 }
 
-function update_button(button, new_text="Copied  ", reset=true) {
-    old_text = button.innerText;
-    button.innerText = new_text;
-    if (reset) {
-        setTimeout(update_button, 2000, button, old_text, false);
-    }
+function update_button(button, new_text = "Copied  ", reset = true) {
+  old_text = button.innerText;
+  button.innerText = new_text;
+  if (reset) {
+    setTimeout(update_button, 2000, button, old_text, false);
+  }
 }
 
 // copy-code-blocks.js ends.

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -11,11 +11,12 @@ const pre_selector = "div.highlight pre";
 document.querySelectorAll(pre_selector).forEach(add_button_to);
 
 function add_button_to(element) {
+    div = document.createElement("div");
+    div.classList.add("copy-button");
     button = document.createElement("button");
-    button.classList.add("copy-button")
-    button.append(document.createTextNode("Copy"));
     button.addEventListener("click", copy_content_of);
-    element.prepend(button);
+    div.append(button);
+    element.prepend(div);
 }
 
 function copy_content_of(event) {

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -24,11 +24,9 @@ function copy_content_of(event) {
   navigator.clipboard.writeText(content).then(() => update_button(this));
 }
 
-function update_button(button, new_text = "Copied  ", reset = true) {
-  button.innerText = new_text;
-  if (reset) {
-    setTimeout(update_button, 2000, button, "", false);
-  }
+function update_button(button, clicked_class = "clicked", timeout_ms = 2000) {
+  button.classList.add(clicked_class);
+  setTimeout(() => button.classList.remove(clicked_class), timeout_ms);
 }
 
 // copy-code-blocks.js ends.

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -1,0 +1,40 @@
+// copy-code-blocks.js
+// Copyright: 2023  Scientific Python Developers
+// Author: Adam Porter <adam@alphapapa.net>
+// License: BSD 3-Clause License
+//   see <https://raw.githubusercontent.com/scientific-python/scientific-python-hugo-theme/main/LICENSE>
+
+// This file implements a button attached to code blocks which copies
+// the code to the clipboard.
+
+// This selector should match the PRE elements, each of which may
+// itself contain the text to be copied, or may contain a CODE element
+// which contains the text to be copied.
+const pre_selector = "div.highlight pre";
+
+document.querySelectorAll(pre_selector).forEach(add_button_to);
+
+function add_button_to(element) {
+    button = document.createElement("button");
+    button.classList.add("copy-button")
+    button.append(document.createTextNode("Copy"));
+    button.addEventListener("click", copy_content_of);
+    element.prepend(button);
+}
+
+function copy_content_of(event) {
+    // Omit "Copy" prefix from the button itself.
+    target = this.parentElement.textContent.substring(4);
+    navigator.clipboard.writeText(target)
+        .then(() => update_button(this) );
+}
+
+function update_button(button, new_text="Copied", reset=true) {
+    old_text = button.innerText;
+    button.innerText = new_text;
+    if (reset) {
+        setTimeout(update_button, 1000, button, old_text, false);
+    }
+}
+
+// copy-code-blocks.js ends.

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -12,8 +12,8 @@ document.querySelectorAll(pre_selector).forEach(add_button_to);
 
 function add_button_to(element) {
     div = document.createElement("div");
-    div.classList.add("copy-button");
     button = document.createElement("button");
+    div.classList.add("copy-button");
     button.addEventListener("click", copy_content_of);
     div.append(button);
     element.prepend(div);
@@ -23,7 +23,7 @@ function copy_content_of(event) {
     // Omit "Copy" prefix from the button itself.
     target = this.parentElement.textContent.substring(4);
     navigator.clipboard.writeText(target)
-        .then(() => update_button(this) );
+        .then(() => update_button(this));
 }
 
 function update_button(button, new_text="Copied  ", reset=true) {

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -20,7 +20,7 @@ function add_button_to(element) {
 }
 
 function copy_content_of(event) {
-  content = this.parentElement.parentElement.textContent;
+  content = this.parentElement.parentElement.textContent + "\n";
   navigator.clipboard.writeText(content).then(() => update_button(this));
 }
 

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -26,11 +26,11 @@ function copy_content_of(event) {
         .then(() => update_button(this) );
 }
 
-function update_button(button, new_text="Copied", reset=true) {
+function update_button(button, new_text="Copied  ", reset=true) {
     old_text = button.innerText;
     button.innerText = new_text;
     if (reset) {
-        setTimeout(update_button, 1000, button, old_text, false);
+        setTimeout(update_button, 2000, button, old_text, false);
     }
 }
 

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -25,10 +25,9 @@ function copy_content_of(event) {
 }
 
 function update_button(button, new_text = "Copied  ", reset = true) {
-  old_text = button.innerText;
   button.innerText = new_text;
   if (reset) {
-    setTimeout(update_button, 2000, button, old_text, false);
+    setTimeout(update_button, 2000, button, "", false);
   }
 }
 

--- a/assets/js/copy-code-blocks.js
+++ b/assets/js/copy-code-blocks.js
@@ -1,8 +1,4 @@
 // copy-code-blocks.js
-// Copyright: 2023  Scientific Python Developers
-// Author: Adam Porter <adam@alphapapa.net>
-// License: BSD 3-Clause License
-//   see <https://raw.githubusercontent.com/scientific-python/scientific-python-hugo-theme/main/LICENSE>
 
 // This file implements a button attached to code blocks which copies
 // the code to the clipboard.

--- a/assets/theme-css/code.scss
+++ b/assets/theme-css/code.scss
@@ -1,0 +1,26 @@
+// Rules for code blocks, including the copy button.
+
+// Selector from "pst/content/_code.scss".
+div[class*="highlight-"],
+div.highlight,
+div.literal-block-wrapper {
+
+  // Copy-to-clipboard button.
+  & .copy-button {
+    bottom: 10px;
+    float: right;
+    font-size: 0.875em;
+    left: 10px;
+    position: relative;
+    visibility: hidden;
+    z-index: 1;
+  }
+  &:hover .copy-button {
+    visibility: visible;
+  }
+
+  & button::before {
+    content: var(--fa-copy);
+    font: var(--fa-font-solid);
+  }
+}

--- a/assets/theme-css/code.scss
+++ b/assets/theme-css/code.scss
@@ -19,7 +19,7 @@ div.literal-block-wrapper {
     visibility: visible;
   }
 
-  & button::before {
+  & button::after {
     content: var(--fa-copy);
     font: var(--fa-font-solid);
   }

--- a/assets/theme-css/code.scss
+++ b/assets/theme-css/code.scss
@@ -32,6 +32,6 @@ div.literal-block-wrapper {
 
   & button::after {
     content: var(--fa-copy);
-    font: var(--fa-font-solid);
+    font: var(--fa-font-regular);
   }
 }

--- a/assets/theme-css/code.scss
+++ b/assets/theme-css/code.scss
@@ -19,6 +19,17 @@ div.literal-block-wrapper {
     visibility: visible;
   }
 
+  & button {
+    border: none;
+
+    &:not(.clicked):hover::before {
+      content: "Copy ";
+    }
+    &.clicked::before {
+      content: "Copied ";
+    }
+  }
+
   & button::after {
     content: var(--fa-copy);
     font: var(--fa-font-solid);

--- a/assets/theme-css/code.scss
+++ b/assets/theme-css/code.scss
@@ -18,22 +18,28 @@ div.literal-block-wrapper {
   &:hover .copy-button {
     visibility: visible;
   }
+  & .chroma .copy-button button {
+    // Fix alignment that the .chroma rules affect.
+    padding: 0.5rem;
+  }
 
   & button {
     background: var(--pst-color-surface);
     border: none;
     color: var(--pst-color-text-base);
 
+    // These classes are changed upon click by the script.
     &:not(.clicked):hover::before {
       content: "Copy ";
     }
     &.clicked::before {
       content: "Copied ";
     }
-  }
 
-  & button::after {
-    content: var(--fa-copy);
-    font: var(--fa-font-regular);
+    &::after {
+      // The Font Awesome copy icon.
+      content: var(--fa-copy);
+      font: var(--fa-font-regular);
+    }
   }
 }

--- a/assets/theme-css/code.scss
+++ b/assets/theme-css/code.scss
@@ -4,7 +4,6 @@
 div[class*="highlight-"],
 div.highlight,
 div.literal-block-wrapper {
-
   // Copy-to-clipboard button.
   & .copy-button {
     bottom: 10px;

--- a/assets/theme-css/code.scss
+++ b/assets/theme-css/code.scss
@@ -20,7 +20,9 @@ div.literal-block-wrapper {
   }
 
   & button {
+    background: var(--pst-color-surface);
     border: none;
+    color: var(--pst-color-text-base);
 
     &:not(.clicked):hover::before {
       content: "Copy ";

--- a/assets/theme-css/pst/content/_code.scss
+++ b/assets/theme-css/pst/content/_code.scss
@@ -12,6 +12,19 @@ div.literal-block-wrapper {
   flex-direction: column;
   width: unset;
   border-radius: $admonition-border-radius;
+
+  & .copy-button {
+    bottom: 10px;
+    float: right;
+    font-size: 0.875em;
+    left: 10px;
+    position: relative;
+    visibility: hidden;
+    z-index: 1;
+  }
+  &:hover .copy-button {
+    visibility: visible;
+  }
 }
 
 // Code blocks with captions

--- a/assets/theme-css/pst/content/_code.scss
+++ b/assets/theme-css/pst/content/_code.scss
@@ -13,6 +13,7 @@ div.literal-block-wrapper {
   width: unset;
   border-radius: $admonition-border-radius;
 
+  // Copy-to-clipboard button.
   & .copy-button {
     bottom: 10px;
     float: right;
@@ -25,7 +26,6 @@ div.literal-block-wrapper {
   &:hover .copy-button {
     visibility: visible;
   }
-
   & button::after {
     content: var(--fa-copy);
     font: var(--fa-font-solid);

--- a/assets/theme-css/pst/content/_code.scss
+++ b/assets/theme-css/pst/content/_code.scss
@@ -25,6 +25,11 @@ div.literal-block-wrapper {
   &:hover .copy-button {
     visibility: visible;
   }
+
+  & button::before {
+    content: var(--fa-copy);
+    font: var(--fa-font-solid);
+  }
 }
 
 // Code blocks with captions

--- a/assets/theme-css/pst/content/_code.scss
+++ b/assets/theme-css/pst/content/_code.scss
@@ -12,24 +12,6 @@ div.literal-block-wrapper {
   flex-direction: column;
   width: unset;
   border-radius: $admonition-border-radius;
-
-  // Copy-to-clipboard button.
-  & .copy-button {
-    bottom: 10px;
-    float: right;
-    font-size: 0.875em;
-    left: 10px;
-    position: relative;
-    visibility: hidden;
-    z-index: 1;
-  }
-  &:hover .copy-button {
-    visibility: visible;
-  }
-  & button::after {
-    content: var(--fa-copy);
-    font: var(--fa-font-solid);
-  }
 }
 
 // Code blocks with captions

--- a/assets/theme-css/pst/content/_code.scss
+++ b/assets/theme-css/pst/content/_code.scss
@@ -26,7 +26,7 @@ div.literal-block-wrapper {
     visibility: visible;
   }
 
-  & button::before {
+  & button::after {
     content: var(--fa-copy);
     font: var(--fa-font-solid);
   }

--- a/assets/theme-css/vars.css
+++ b/assets/theme-css/vars.css
@@ -15,5 +15,6 @@
 
   --spht-footer-height: 6em;
 
+  /* Font Awesome icon variables. */
   --fa-copy: "\f0c5";  /* fa-solid fa-copy */
 }

--- a/assets/theme-css/vars.css
+++ b/assets/theme-css/vars.css
@@ -14,4 +14,6 @@
   --colorYellow: rgb(255, 197, 83);
 
   --spht-footer-height: 6em;
+
+  --fa-copy: "\f0c5";  /* fa-solid fa-copy */
 }


### PR DESCRIPTION
This implements a simple, bespoke button attached to code blocks that copies the code to the clipboard.  (Rather than use, e.g. [clipboard.js](https://clipboardjs.com/), which is 3 KB gzipped.)

It looks like this:

<details><summary>Details</summary>
<p>

![Screen Shot 2023-11-16 at 17 17 29](https://github.com/scientific-python/scientific-python-hugo-theme/assets/601365/44ef62ed-5857-4a57-bf90-b502f1c2ee3f)


</p>
</details> 

It still needs a bit of visual tweaking in the CSS for, e.g. one-line, very wide code blocks, but that shouldn't take much more work.