### PR TITLE
Change/Fix: Include "theme-css/*.scss" files

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -23,8 +23,8 @@
 
 <!-- SASS -->
 {{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss")
-           | append (resources.Match "theme-css/*.scss")
-           | append (resources.Match "css/*.scss") -}}
+           | append (resources.Match "theme-css/**/*.scss")
+           | append (resources.Match "css/**/*.scss") -}}
 {{- range $sass -}}
 
 {{ with . }}  <!-- Skips nil elements from appending empty resources.Match slices. -->
@@ -41,8 +41,8 @@
 {{- end -}}
 {{- end -}}
 
-{{- $themeCssFiles := resources.Match "theme-css/*.css" -}}
-{{- $userCssFiles := resources.Match "css/*.css" -}}
+{{- $themeCssFiles := resources.Match "theme-css/**/*.css" -}}
+{{- $userCssFiles := resources.Match "css/**/*.css" -}}
 {{- $cssFiles := $themeCssFiles | append $userCssFiles }}
 
 {{- range $cssFiles -}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -23,8 +23,8 @@
 
 <!-- Process and include Sass files. -->
 {{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss")
-           | append (resources.Match "theme-css/**/*.scss")
-           | append (resources.Match "css/**/*.scss") -}}
+           | append (resources.Match "theme-css/*.scss")
+           | append (resources.Match "css/*.scss") -}}
 
 {{- range $sass -}}
   {{ with . }}  <!-- Skips nil elements from appending empty resources.Match slices. -->
@@ -40,8 +40,8 @@
 {{- end -}}
 
 <!-- Process and include plain CSS files. -->
-{{- $themeCssFiles := resources.Match "theme-css/**/*.css" -}}
-{{- $userCssFiles := resources.Match "css/**/*.css" -}}
+{{- $themeCssFiles := resources.Match "theme-css/*.css" -}}
+{{- $userCssFiles := resources.Match "css/*.css" -}}
 {{- $cssFiles := $themeCssFiles | append $userCssFiles }}
 
 {{- range $cssFiles -}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -21,38 +21,35 @@
 <!-- Fallback font for symbols (such as "🛈"). --
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols+2">
 
-<!-- SASS -->
+<!-- Process and include Sass files. -->
 {{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss")
            | append (resources.Match "theme-css/**/*.scss")
            | append (resources.Match "css/**/*.scss") -}}
+
 {{- range $sass -}}
-
-{{ with . }}  <!-- Skips nil elements from appending empty resources.Match slices. -->
-{{- $targetFile := printf "%s.scss" . -}}
-
-{{- if $inServerMode -}}
-{{ $css := resources.Get . | resources.ExecuteAsTemplate $targetFile $page | toCSS $cssOpts -}}
-<link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}">
-{{ else }}
-{{ $css := resources.Get . | resources.ExecuteAsTemplate $targetFile $page | toCSS $cssOpts | minify | fingerprint -}}
-<link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
+  {{ with . }}  <!-- Skips nil elements from appending empty resources.Match slices. -->
+    {{- $targetFile := printf "%s.scss" . -}}
+    {{- if $inServerMode -}}
+      {{ $css := resources.Get . | resources.ExecuteAsTemplate $targetFile $page | toCSS $cssOpts -}}
+      <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}">
+    {{ else }}
+      {{ $css := resources.Get . | resources.ExecuteAsTemplate $targetFile $page | toCSS $cssOpts | minify | fingerprint -}}
+      <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
-{{- end -}}
-{{- end -}}
-
+<!-- Process and include plain CSS files. -->
 {{- $themeCssFiles := resources.Match "theme-css/**/*.css" -}}
 {{- $userCssFiles := resources.Match "css/**/*.css" -}}
 {{- $cssFiles := $themeCssFiles | append $userCssFiles }}
 
 {{- range $cssFiles -}}
-
-{{ if $inServerMode -}}
-{{ $custom_style := . | resources.ExecuteAsTemplate . $page -}}
-<link rel="stylesheet" href="{{ $custom_style.RelPermalink }}">
-{{ else }}
-{{ $custom_style := . | resources.ExecuteAsTemplate . $page | minify | fingerprint -}}
-<link rel="stylesheet" href="{{ $custom_style.RelPermalink }}" integrity="{{ $custom_style.Data.Integrity }}">
-{{- end -}}
-
+  {{ if $inServerMode -}}
+    {{ $custom_style := . | resources.ExecuteAsTemplate . $page -}}
+    <link rel="stylesheet" href="{{ $custom_style.RelPermalink }}">
+  {{ else }}
+    {{ $custom_style := . | resources.ExecuteAsTemplate . $page | minify | fingerprint -}}
+    <link rel="stylesheet" href="{{ $custom_style.RelPermalink }}" integrity="{{ $custom_style.Data.Integrity }}">
+  {{- end -}}
 {{- end -}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -22,9 +22,12 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols+2">
 
 <!-- SASS -->
-{{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss") | append (resources.Match "css/*.scss") -}}
+{{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss")
+           | append (resources.Match "theme-css/*.scss")
+           | append (resources.Match "css/*.scss") -}}
 {{- range $sass -}}
 
+{{ with . }}  <!-- Skips nil elements from appending empty resources.Match slices. -->
 {{- $targetFile := printf "%s.scss" . -}}
 
 {{- if $inServerMode -}}
@@ -35,6 +38,7 @@
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
 {{- end -}}
 
+{{- end -}}
 {{- end -}}
 
 {{- $themeCssFiles := resources.Match "theme-css/*.css" -}}


### PR DESCRIPTION
This includes Sass files in the `theme-css` directory (previously they were only included from the downstream `css` directory).

To be used in <https://github.com/scientific-python/scientific-python-hugo-theme/pull/418>.