### PR TITLE
Updated keyfeatures.css

### DIFF
--- a/assets/theme-css/keyfeatures.css
+++ b/assets/theme-css/keyfeatures.css
@@ -31,7 +31,7 @@
 .keyfeatures-box-text {
   line-height: 1.5;
   margin: 15px;
-  height: 6em;
+  height: auto;
   overflow: hidden;
 }
 

--- a/assets/theme-css/keyfeatures.css
+++ b/assets/theme-css/keyfeatures.css
@@ -32,6 +32,7 @@
   line-height: 1.5;
   margin: 15px;
   height: auto;
+  min-height: 6em;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Changed the height of .keyfeatures-box-text from a fixed 6em to auto to accomodate longer texts. The box height now depends on the longest text in each row. See the issue on the scipy.org main page or the top screenshot attached. ("Enjoy the flexibility of Python with the speed of[...]" & "SciPy provides algorithms for
optimization, integration, interpolation, eigenvalue problems, algebraic equations, differential equations,[...]") The bottom screenshot shows the scipy.org website with the "auto" patch.
<img width="1211" alt="scipy-height-issue" src="https://github.com/scientific-python/scientific-python-hugo-theme/assets/79815526/0c03c830-ff7c-4109-9225-bf656c322afe">
<img width="1211" alt="Untitled" src="https://github.com/scientific-python/scientific-python-hugo-theme/assets/79815526/28b6564c-066a-45aa-a6bd-eca0d27976e3">

