### PR TITLE
Fix: (css.html) Unify types

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -22,8 +22,8 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols+2">
 
 <!-- Process and include Sass files. -->
-{{- $sass := (slice "theme-css/pst/pydata-sphinx-theme.scss")
-           | append (resources.Match "theme-css/*.scss")
+{{- $sass := append (resources.Get "theme-css/pst/pydata-sphinx-theme.scss")
+                    (resources.Match "theme-css/*.scss")
            | append (resources.Match "css/*.scss") -}}
 
 {{- range $sass -}}


### PR DESCRIPTION
Previously a slice holding a string was being appended to slices of
resource.Resources, which could cause an error in the build process.
Now resource.Resources are used for all of these files.

Needed to fix branch https://github.com/alphapapa/numpy.org/commits/theme-0.5, which is needed to fix https://github.com/numpy/numpy.org/issues/705.