### PR TITLE
Fix: (bulma.css) .navbar-dropdown background-color

### DIFF
--- a/assets/theme-css/bulma.css
+++ b/assets/theme-css/bulma.css
@@ -373,7 +373,7 @@ a.navbar-item:hover {
     margin-left: auto;
   }
   .navbar-dropdown {
-    background-color: #fff;
+    background-color: var(--pst-color-surface);
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
     border-top: 2px solid #dbdbdb;


### PR DESCRIPTION
Fixes appearance in dark mode.

See <https://github.com/numpy/numpy.org/issues/707#issue-2031310758>.