### PR TITLE
Increase color contrast in footer

### DIFF
--- a/assets/theme-css/footer.css
+++ b/assets/theme-css/footer.css
@@ -35,7 +35,7 @@
 }
 
 .footer-item a:hover {
-  color: var(--pst-color-link-hover);
+  color: var(--colorPrimaryLight);
 }
 
 .footer-actions {


### PR DESCRIPTION
Fix #457. I am using the same hoover color as used in the `about` button and news banner.

![2024-01-26T08:22:48,295534305-08:00](https://github.com/scientific-python/scientific-python-hugo-theme/assets/123428/5bc2a2c6-69ae-4729-b5af-0a40e3104a4b)

https://coolors.co/contrast-checker/4dabcf-013243