### PR TITLE
Add a placeholder for blog comments

### DIFF
--- a/layouts/partials/posts/post.html
+++ b/layouts/partials/posts/post.html
@@ -14,6 +14,7 @@
       </div>
       {{ end }}
       {{ .Content }}
+      {{ partial "posts/comments.html" .}}
     </div>
   </div>
   {{ partial "shortcuts.html" . }}


### PR DESCRIPTION
Whether we add comments or not, it's quite reasonable to have a placeholder for them, otherwise blog authors wouldn't be able to add them after-the-fact.