### PR TITLE
Add PST cards in grid

### DIFF
--- a/assets/theme-css/pst-deps/sphinx-design/_grid.scss
+++ b/assets/theme-css/pst-deps/sphinx-design/_grid.scss
@@ -1,0 +1,21 @@
+.sd-container,
+.sd-container-fluid,
+.sd-container-lg,
+.sd-container-md,
+.sd-container-sm,
+.sd-container-xl {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--sd-gutter-x, 0.75rem);
+  padding-right: var(--sd-gutter-x, 0.75rem);
+  width: 100%;
+}
+
+.sd-row {
+  --sd-gutter-x: 1.5rem;
+  --sd-gutter-y: 0;
+  display: flex;
+  margin-top: calc(var(--sd-gutter-y) * -1);
+  margin-right: calc(var(--sd-gutter-x) * -0.5);
+  margin-left: calc(var(--sd-gutter-x) * -0.5);
+}

--- a/assets/theme-css/scientific-python-hugo-theme.scss
+++ b/assets/theme-css/scientific-python-hugo-theme.scss
@@ -1,4 +1,5 @@
 @import "./pst-deps/sphinx-design/badges";
 @import "./pst-deps/sphinx-design/card";
+@import "./pst-deps/sphinx-design/grid";
 @import "./pst/pydata-sphinx-theme";
 @import "./spht/code";

--- a/layouts/shortcodes/grid.html
+++ b/layouts/shortcodes/grid.html
@@ -1,0 +1,32 @@
+{{/*
+
+doc: Grids.
+
+{{< grid >}}
+
+{{< card title="Only heading" >}}{{< /card >}}
+
+{{< card >}}
+Only body.
+
+But with multiple text paragraphs.
+{{< /card >}}
+
+{{< card title="Heading and body" >}}
+Content of the third card.
+
+{{< badge primary >}}
+Sample badge
+{{< /badge >}}
+
+{{< /card >}}
+
+{{< /grid >}}
+
+*/}}
+
+<div class="sd-container-fluid">
+<div class="sd-row">
+  {{ .Inner }}
+</div>
+</div>


### PR DESCRIPTION
Depends on #463 .

Maybe the cards information should be in a yaml file or something?
Then the grid shortcode could take the yaml file as the only input.

The cards may have a lot of features (buttons, headers, footers, titles, etc...)

pydata-sphinx-theme seems to just talk about cards in grids.
https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/web-components.html#cards
https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/index.md
https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/user_guide/web-components.rst

sphinx-design has both.
https://sphinx-design.readthedocs.io/en/latest/cards.html
https://sphinx-design.readthedocs.io/en/latest/grids.html

I am thinking we could use the grid of cards to replace:
https://github.com/scientific-python/scientific-python-hugo-theme/blob/main/layouts/partials/panel.html
https://github.com/scientific-python/scientific-python-hugo-theme/blob/main/layouts/partials/keyfeatures.html