### PR TITLE
Add kaushalmodi's atom feed sub-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/hugo-atom-feed"]
+	path = themes/hugo-atom-feed
+	url = https://github.com/kaushalmodi/hugo-atom-feed


### PR DESCRIPTION
This is part of a larger move to integrate all blog functionality into the theme, instead of into blog.scientific-python.org.

Before, we used to use a custom fork of kaushalmodi's theme. However, with

https://github.com/kaushalmodi/hugo-atom-feed/pull/20

merged, we can make use of the original.

---

TODO: once this is merged, update theme on blog.sp and remove submodule.