### PR TITLE
Add author profiles

### DIFF
--- a/layouts/partials/posts/meta.html
+++ b/layouts/partials/posts/meta.html
@@ -1,7 +1,16 @@
 <div class="post-meta">
-  <span class="post-authors">
+<span class="post-authors">
     {{- range .Params.author -}}
-    <div class="post-author"><i class="fa-solid fa-user"></i> {{ . }}</div>
+    {{ $author := trim (index (findRE `[^<]*` . 1) 0) "\n\r " }}
+    {{ $handle := index (index (findRESubmatch `<(.*?)>` . 1) 0) 1 }}
+    <div class="post-author">
+    <i class="fa-solid fa-user"></i>
+      {{ if $handle }}
+      <a href="/authors/{{ $handle }}">{{ $author }}</a>
+      {{- else }}
+      {{- $author }}
+      {{- end }}
+    </div>
     {{- end -}}
   </span>
   {{ if .Date }}


### PR DESCRIPTION
With this change, I can add `/content/authors/stefanv.md` with:

```markdown
---
title: Stéfan van der Walt
---

👋 Hi!

- My website is https://mentat.za.net
- You can reach me on Mastodon at https://emacs.ch/@stefanv
```

In the blogpost, I change the author field to:

```yaml
author: ["Stéfan van der Walt <stefanv>"]
```

And it renders as a link on the blog post:

----
<img src="https://github.com/scientific-python/scientific-python-hugo-theme/assets/45071/2bac0402-e46f-40a4-a0ba-227da14df5f6" alt="author link in blog post" width="350px">

----

As well as the matching profile page:

----
<img src="https://github.com/scientific-python/scientific-python-hugo-theme/assets/45071/a946ed3e-2d1b-4fc1-94d2-fc2fb5e64760" alt="rendered profile page" width="300px">

----

Requested by @albertcthomas