### PR TITLE
Add include shortcode

### DIFF
--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -1,0 +1,2 @@
+{{ $file := .Get 0 }}
+{{ (printf "%s%s" .Page.File.Dir $file) | readFile | replaceRE "^---[\\s\\S]+?---" "" | markdownify }}


### PR DESCRIPTION
Useful for including shortcodes saved as stand-alone files. I will use this in a follow-up PR to use a grid of cards to generate the team galleries.