### PR TITLE
Use column value for smallest screens

### DIFF
--- a/layouts/partials/_elements/grid.html
+++ b/layouts/partials/_elements/grid.html
@@ -13,7 +13,7 @@
   {{- $sm := index $columns 1 }}
   {{- $md := index $columns 2 }}
   {{- $lg := index $columns 3 }}
-  <div class="sd-row sd-row-cols-1 sd-row-cols-xs-{{ $xs }} sd-row-cols-sm-{{ $sm }} sd-row-cols-md-{{ $md }} sd-row-cols-lg-{{ $lg }} sd-g-2 sd-g-xs-{{ $xs }} sd-g-sm-{{ $sm }} sd-g-md-{{ $md }} sd-g-lg-{{ $lg }}">
+  <div class="sd-row sd-row-cols-{{ $xs }} sd-row-cols-xs-{{ $xs }} sd-row-cols-sm-{{ $sm }} sd-row-cols-md-{{ $md }} sd-row-cols-lg-{{ $lg }} sd-g-2 sd-g-xs-{{ $xs }} sd-g-sm-{{ $sm }} sd-g-md-{{ $md }} sd-g-lg-{{ $lg }}">
 {{- end }}
 {{- range $key, $d := $items -}}
   {{- if eq $d.type "card" }}


### PR DESCRIPTION
Use number of columns specified for xs screens for screens smaller than xs. Before it was hard-coded to 1.