### PR TITLE
Remove unneeded bulma css

### DIFF
--- a/assets/theme-css/bulma.css
+++ b/assets/theme-css/bulma.css
@@ -1,17 +1,5 @@
 /*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */
 /*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
-iframe {
-  border: 0;
-}
-article,
-footer,
-header {
-  display: block;
-}
-span {
-  font-style: inherit;
-  font-weight: inherit;
-}
 .container {
   flex-grow: 1;
   margin: 0 auto;

--- a/assets/theme-css/videos.css
+++ b/assets/theme-css/videos.css
@@ -1,3 +1,7 @@
+iframe {
+  border: 0;
+}
+
 .youtube {
   width: 100%;
   display: flex;


### PR DESCRIPTION
- [x] iframe is only used with youtube (which may be removed soon #522)
- [x] `font-style` and `font-weight` are inherited by default
- [x] article, footer, and header don't seem to need display set to block
  - we use `<article>` in [layouts/partials/section/section.html](https://github.com/scientific-python/scientific-python-hugo-theme/blob/2a04a1c3caaeac6f17e120a08432189357dd4887/layouts/partials/section/section.html#L13), [layouts/partials/posts/list-with-summary.html](https://github.com/scientific-python/scientific-python-hugo-theme/blob/2a04a1c3caaeac6f17e120a08432189357dd4887/layouts/partials/posts/list-with-summary.html#L5), and [layouts/partials/posts/list-without-summary.html](https://github.com/scientific-python/scientific-python-hugo-theme/blob/2a04a1c3caaeac6f17e120a08432189357dd4887/layouts/partials/posts/list-without-summary.html#L5)
  - we use `<footer>` in [layouts/partials/footer.html](https://github.com/scientific-python/scientific-python-hugo-theme/blob/2a04a1c3caaeac6f17e120a08432189357dd4887/layouts/partials/footer.html#L9) 
  - we use `<header>` in [layouts/partials/scientific-domains.html](https://github.com/numpy/numpy.org/blob/377ff102fe3b58e4ad33d7213abc9721cf5f3fa1/layouts/partials/scientific-domains.html#L11)