### PR TITLE
Remove is-max-widescreen class

### DIFF
--- a/assets/theme-css/bulma.css
+++ b/assets/theme-css/bulma.css
@@ -16,11 +16,6 @@
     max-width: 1152px;
   }
 }
-@media screen and (min-width: 1408px) {
-  .container:not(.is-max-widescreen) {
-    max-width: 1344px;
-  }
-}
 @media screen and (max-width: 768px) {
   .is-hidden-mobile {
     display: none !important;

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
 {{- $navbarLogo     := .Site.Params.navbarlogo }}
 
 <footer id="footer">
-  <div class="container is-max-widescreen">
+  <div class="container">
     <div id="footer-columns">
       <div id="footer-logo-column">
         <img id="footer-logo" src="{{ printf "/images/%s" $logo | relURL }}" alt="{{ $title }} logo. {{ $navbarLogo.altText }}">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -3,7 +3,7 @@
 {{- $navbarLogo     := .Site.Params.navbarlogo }}
 {{- $navbarLogoShow := .Site.Params.navbarlogoshow }}
 <nav id="nav" class="navbar" role="navigation" aria-label="main navigation">
-  <div class="container is-max-widescreen">
+  <div class="container">
     <div class="navbar-brand">
       {{ if or (not .IsHome) ($navbarLogoShow) }}
       {{- if $navbarLogo}}


### PR DESCRIPTION
This was almost never used. The only thing it changes is:
![2024-03-24T03:48:09,412033147-07:00](https://github.com/scientific-python/scientific-python-hugo-theme/assets/123428/a2131a57-311e-48bc-b880-77e5a7f03ea4)
becomes
![2024-03-24T03:48:55,178664656-07:00](https://github.com/scientific-python/scientific-python-hugo-theme/assets/123428/78b51395-d9a6-472b-9c0f-e21217f6dc82)
on full hd screens now. If numpy.org wants to keep the larger spacing for case studies, we can add it there. Removing here since we weren't using it anywhere else.