### PR TITLE
Error for missing breadcrumbs (scientific-python/blog.scientific-python.org#158)

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,6 +1,11 @@
 <ul id="breadcrumbs" class="bd-breadcrumbs">
   {{- range $index, $ := .Ancestors.Reverse }}
   {{ if $index }}
+
+  {{ or .Title
+        (errorf "Missing breadcrumb: Page has no \"title\" field.  Filename:%q"
+                .File.Filename) }}
+
   <li class="breadcrumb-item"><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
   {{ else }}
   <li class="breadcrumb-item breadcrumb-home"><a href="{{ .RelPermalink }}"><i class="fas fa-home"></i></a></li>


### PR DESCRIPTION
* layouts/partials/breadcrumbs.html: Log an error and fail the build
if a breadcrumb is missing (i.e. if a page used in a breadcrumb has a
missing "title" field in its front matter).

This only applies to content pages which are referred to in
breadcrumbs; other pages are still allowed to not have titles.

See <https://github.com/scientific-python/blog.scientific-python.org/issues/158>.

Output from the build (e.g. `make serve-dev`) looks like:
```
Start building sites … 
hugo v0.120.3-a4892a07b41b7b3f1f143140ee4ec0a9a5cf3970+extended linux/amd64 BuildDate=2023-11-01T17:57:00Z VendorInfo=gohugoio

ERROR Missing breadcrumb: Page has no "title" field.  Filename:"/home/me/src/scientific-python-hugo-theme/blog/content/posts/scipy/internships/_index.md"
Total in 953 ms
Error: error building site: logged 1 error(s)
make: *** [Makefile:68: blog] Error 1
```