### PR TITLE
Fix grid item

### DIFF
--- a/layouts/partials/_elements/item.html
+++ b/layouts/partials/_elements/item.html
@@ -1,15 +1,15 @@
 {{- $columns := default "" .columns -}}
   {{- if eq $columns ""}}
-    <div class="sd-col sd-d-flex-row">
+    <div class="sd-col sd-d-flex-column">
   {{- else if eq $columns "auto"}}
-    <div class="sd-col sd-d-flex-row sd-col-auto sd-col-xs-auto sd-col-sm-auto sd-col-md-auto sd-col-lg-auto">
+    <div class="sd-col sd-d-flex-column sd-col-auto sd-col-xs-auto sd-col-sm-auto sd-col-md-auto sd-col-lg-auto">
   {{- else }}
     {{- $columns := split $columns " " }}
     {{- $xs := index $columns 0 }}
     {{- $sm := index $columns 1 }}
     {{- $md := index $columns 2 }}
     {{- $lg := index $columns 3 }}
-    <div class="sd-col sd-d-flex-row sd-col-{{ $xs }} sd-col-xs-{{ $xs }} sd-col-sm-{{ $sm }} sd-col-md-{{ $md }} sd-col-lg-{{ $lg }}">
+    <div class="sd-col sd-d-flex-column sd-col-{{ $xs }} sd-col-xs-{{ $xs }} sd-col-sm-{{ $sm }} sd-col-md-{{ $md }} sd-col-lg-{{ $lg }}">
   {{- end }}
       <div>
         {{- with (trim .body "\n") }}


### PR DESCRIPTION
It looks like we use `sd-d-flex-column` for grid-items, but `sd-d-flex-row` for grid-card-items.