### PR TITLE
Update hugo (0.127.0)

### DIFF
--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.8" # netlify currently only support 2.7 and 3.8
-  HUGO_VERSION = "0.126.2"
+  HUGO_VERSION = "0.127.0"
   DART_SASS_VERSION = "1.77.5"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 


### PR DESCRIPTION
Hugo [0.126.3](https://github.com/gohugoio/hugo/releases/tag/v0.126.3) broke our check-links tests:
```
7:41:30 AM:   ✖ FAIL load public/blog/news
7:41:30 AM:   | operator: load
7:41:30 AM:   | expected: 200 public/blog/news
7:41:30 AM:   |   actual: ENOENT: no such file or directory, open '/opt/build/repo/doc/public/blog/news'
7:41:30 AM:   |       at: public/blog/index.html:105:36 <a href="./news">...</a>
7:41:30 AM:   1779 tests
7:41:30 AM:      3 skipped
7:41:30 AM:   1778 passed
7:41:30 AM:      1 failed
7:41:31 AM: Failed during stage 'building site': Build script returned non-zero exit code: 2 (https://ntl.fyi/exit-code-2)
```
with 0.126.2 we got
```
7:38:19 AM:   1778 tests
7:38:19 AM:      3 skipped
7:38:19 AM:   1778 passed
```

Not sure what is happening, but we used to have 1778 tests (now we have 1779 tests with one failing). We do have
https://blog.scientific-python.org/tags/news/
And this line is in the source for blog.scientific-python.org:
```
<span class="post-tag"><a href="/tags/news">#news</a></span>
```

The same problem occurs with 0.127.0.