### PR TITLE
Handle hugo deprecation

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,7 +1,7 @@
 <!-- Include all theme CSS filenames here -->
 {{- $page := . -}}
 
-{{- $inServerMode := .Site.IsServer -}}
+{{- $inServerMode := hugo.IsServer -}}
 {{- $serverOpts := cond ($inServerMode) (dict "enableSourceMap" true) (dict "outputStyle" "compressed") -}}
 {{- $sassCompiler := dict "transpiler" "dartsass" -}}
 {{- $cssOpts := collections.Merge $sassCompiler $serverOpts -}}

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -1,4 +1,4 @@
-{{- $inServerMode := .Site.IsServer -}}
+{{- $inServerMode := hugo.IsServer -}}
 
 <!-- Font Awesome -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" integrity="sha384-3ve3u7etWcm2heCe4TswfZSAYSg2jR/EJxRHuKM5foOiKS8IJL/xRlvmjCaHELBz" crossorigin="anonymous"></script>


### PR DESCRIPTION
WARN  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in a future release. Use hugo.IsServer instead.