### PR TITLE
Style mermaid tooltips

### DIFF
--- a/assets/theme-css/styles.css
+++ b/assets/theme-css/styles.css
@@ -183,6 +183,18 @@ a.headerlink {
   margin-top: -0.5rem;
 }
 
+.mermaidTooltip {
+  position: absolute;
+  text-align: center;
+  max-width: 200px;
+  padding: 2px;
+  font-size: 80%;
+  background: var(--pst-color-on-background);
+  border: 1px solid var(--pst-color-border);
+  pointer-events: none;
+  z-index: 100;
+}
+
 /* Local Variables: */
 /* css-indent-offset: 2 */
 /* End: */


### PR DESCRIPTION
Without styling, Mermaid tooltips (like on the [SPEC flow diagram](https://scientific-python.org/specs/purpose-and-process/#decision-points)) are invisible.

----

Compare behavior: [current website](https://scientific-python.org/specs/purpose-and-process/#decision-points) vs [proposed change](https://deploy-preview-639--scientific-python-hugo-theme.netlify.app/main/specs/purpose-and-process/#decision-points)
(Hover over the boxes.)