### PR TITLE
Use `⌘` (`KeyboardEvent.metaKey`) with Pagefind search toggle on macOS

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -51,7 +51,6 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-
   document
     .querySelector(".search-button")
     .addEventListener("click", showSearch);

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -50,8 +50,8 @@ window.addEventListener("DOMContentLoaded", () => {
 
   window.addEventListener("keydown", (evt) => {
     if (
-      evt.key === "k" &&
-      ((isMac && evt.metaKey) || (!isMac && evt.ctrlKey))
+      ((isMac && evt.metaKey) || (!isMac && evt.ctrlKey)) &&
+      evt.key === "k"
     ) {
       evt.preventDefault(); // prevents default browser behaviour
       toggleSearch();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -45,10 +45,11 @@ window.addEventListener("DOMContentLoaded", () => {
   });
 
   window.addEventListener("keydown", (evt) => {
-    if (evt.key === "k" && evt.ctrlKey) {
+    if (evt.key === "k" && (evt.ctrlKey || evt.metaKey)) {
       toggleSearch();
     }
   });
+
 
   document
     .querySelector(".search-button")

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -2,9 +2,13 @@
 
 window.addEventListener("DOMContentLoaded", () => {
   let searchDialog = document.querySelector(".search-dialog");
+  let searchButton = document.getElementById("search-button");
 
   // Do nothing here if search is not enabled.
-  if (!searchDialog) return;
+  if (!searchDialog || !searchButton) return;
+
+  const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent);
+  searchButton.title = `Search (${isMac ? "⌘" : "Ctrl"} + K)`;
 
   new PagefindUI({
     element: ".search-dialog",
@@ -45,8 +49,11 @@ window.addEventListener("DOMContentLoaded", () => {
   });
 
   window.addEventListener("keydown", (evt) => {
-    if (evt.key === "k" && (evt.ctrlKey || evt.metaKey)) {
-      evt.preventDefault();
+    if (
+      evt.key === "k" &&
+      ((isMac && evt.metaKey) || (!isMac && evt.ctrlKey))
+    ) {
+      evt.preventDefault(); // prevents default browser behaviour
       toggleSearch();
     }
   });

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -46,6 +46,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   window.addEventListener("keydown", (evt) => {
     if (evt.key === "k" && (evt.ctrlKey || evt.metaKey)) {
+      evt.preventDefault();
       toggleSearch();
     }
   });

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -26,7 +26,7 @@
 
       <div class="navbar-end">
         {{- if .Site.Params.search }}
-        <button class="search-button" title="Search (Ctrl/Cmd+K)">
+        <button id="search-button" class="search-button" title="Search">
           <i class="fa-solid fa-magnifying-glass fa-lg"></i>
         </button>
         {{- end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -26,7 +26,7 @@
 
       <div class="navbar-end">
         {{- if .Site.Params.search }}
-        <button class="search-button" title="Search (Ctrl+k)">
+        <button class="search-button" title="Search (Ctrl/Cmd+K)">
           <i class="fa-solid fa-magnifying-glass fa-lg"></i>
         </button>
         {{- end }}


### PR DESCRIPTION
## Description

This is a very small PR that should enable searching through the Command (⌘) key on macOS, which is the standard method to invoke the search bar followed by the PST. This allows both the use of <kbd>⌘</kbd> + <kbd>K</kbd> on macOS and the use of  <kbd>Ctrl</kbd> + <kbd>K</kbd> on Linux and Windows. I've added the `KeyboardEvent.metaKey` property for this based on the MDN docs: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey.

~~I don't think it is warranted to check for the host's operating system – I did think about it but since there is no reasonable alternative for this property on Windows-based keyboards besides the button for the Windows logo, this change is short and not too invasive in that sense. :)~~ I added some additional code to the event listener present so that we get the right tooltips based on the host's operating system. :)