### PR TITLE
Fix: Ensure Navbar Links Are Crawlable

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -34,9 +34,9 @@
         {{- range $navbar }}
         {{- if .sublinks }}
         <div class="navbar-item has-dropdown">
-          <a class="navbar-link">
+          <span class="navbar-link">
             {{ .title | safeHTML }}
-          </a>
+          </span>
 
           <div class="navbar-dropdown">
             {{- range .sublinks }}


### PR DESCRIPTION
#### **Issue**  
Google flagged an issue with some `<a>` elements in the navbar:  
- The **"More"** dropdown toggle was missing an `href`, making it uncrawlable.  
- Some links used `./`, which can cause issues with search engine discovery.  

#### **Fixes**  
- Changed the **"More"** dropdown `<a>` to a `<span>` since it's not a clickable link.  
- Updated `./` paths to **absolute paths** (`/user_guide/`, `/shortcodes/`, etc.).  
- Ensured all anchor tags have valid `href` attributes.  

#### **Why This Matters**  
- Improves **SEO** by making links properly crawlable.  
- Prevents Google search console errors related to invalid/missing `href` attributes.  
