### PR TITLE
Support named parameters in the `figure` shortcode

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -3,13 +3,13 @@
 doc: Figures
 
 {{< figure >}}
-src = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
-alt = 'Cute puppies'
+src = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
+alt = "Cute puppies"
 height = 200
 width = 200
-title = 'Figure title'
-attribution = 'Figure Credits: Cute puppies image from unsplash.com'
-attributionlink = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
+title = "Figure title"
+attribution = "Figure Credits: Cute puppies image from unsplash.com"
+attributionlink = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
 caption = '''
 A figure is an image with a caption. Figures may also include a tile, legend, and/or attribution.
 '''
@@ -21,11 +21,11 @@ This paragraph is also part of the legend.
 {{< /figure >}}
 
 {{< figure >}}
-src = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
-alt = 'Cute puppies'
-attribution = 'Figure Credits: Cute puppies image from unsplash.com'
-attributionlink = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
-align = 'left'
+src = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
+alt = "Cute puppies"
+attribution = "Figure Credits: Cute puppies image from unsplash.com"
+attributionlink = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
+align = "left"
 height = 150
 width = 150
 caption = '''
@@ -40,14 +40,15 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 This shortcode can also be used with named parameters. The following example shows how to do so:
 
 {{< figure
-src = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
-alt = "Cute puppies"
-attribution = "Figure Credits: Cute puppies image from unsplash.com"
-attributionlink = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
-align = "right"
-height = "150"
-width = "150"
-caption = "A figure with right alignment." >}}
+    src = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
+    alt = "Cute puppies"
+    attribution = "Figure Credits: Cute puppies image from unsplash.com"
+    attributionlink = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
+    align = "right"
+    height = 150
+    width = 150
+    caption = "A figure with right alignment."
+>}}
 
 {{< /figure >}}
 

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -3,13 +3,13 @@
 doc: Figures
 
 {{< figure >}}
-src = 'https://source.unsplash.com/200x200/daily?cute+puppy'
+src = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
 alt = 'Cute puppies'
 height = 200
 width = 200
 title = 'Figure title'
-attribution = 'Figure Credits: Daily cute puppy image from unslash.com'
-attributionlink = 'https://source.unsplash.com/200x200/daily?cute+puppy'
+attribution = 'Figure Credits: Cute puppies image from unsplash.com'
+attributionlink = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
 caption = '''
 A figure is an image with a caption. Figures may also include a tile, legend, and/or attribution.
 '''
@@ -21,10 +21,10 @@ This paragraph is also part of the legend.
 {{< /figure >}}
 
 {{< figure >}}
-src = 'https://source.unsplash.com/200x200/daily?cute+puppy'
+src = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
 alt = 'Cute puppies'
-attribution = 'from unslash.com'
-attributionlink = 'https://source.unsplash.com/200x200/daily?cute+puppy'
+attribution = 'Figure Credits: Cute puppies image from unsplash.com'
+attributionlink = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
 align = 'left'
 height = 150
 width = 150

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -39,14 +39,31 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 */}}
 
-{{- $figure := .Inner | transform.Unmarshal -}}
+{{- $useParams := true -}}
+{{- $figure := dict -}}
+
+{{- if strings.TrimSpace .Inner -}}
+    {{- if not .IsNamedParams -}}
+    {{- $useParams = false -}}
+    {{- $figure = .Inner | transform.Unmarshal -}}
+    {{- end -}}
+{{- end -}}
+
+{{/* If we're using params, collect them. */}}
+{{- if $useParams -}}
+    {{- range $key, $value := .Params -}}
+    {{- $figure = merge $figure (dict $key $value) -}}
+    {{- end -}}
+{{- end -}}
+
 {{- $align := default "default" $figure.align -}}
 {{- $id := printf "id%03d" $.Ordinal -}}
+
 <figure class="align-{{ $align }}" id="{{ $id }}">
-{{- $m := newScratch -}}
-{{- $m.Set "image" $figure -}}
-{{- $m.SetInMap "image" "align" "center" -}}
-{{ partial "_elements/image.html" (dict "data" $m.Values.image) }}
+{{/* Create a clean copy of figure data with align center for image */}}
+{{- $image := merge $figure (dict "align" "center") -}}
+{{ partial "_elements/image.html" (dict "data" $image) }}
+
 <figcaption>
 {{- with $figure.title -}}
 <strong class="caption-title">{{ . }}</strong><a class="headerlink" href="#{{ $id  }}" title="Link to this image">#</a><br>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -37,6 +37,24 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
+This shortcode can also be used with named parameters. The following example shows how to do so:
+
+{{< figure
+src = "https://images.unsplash.com/photo-1546238232-20216dec9f72"
+alt = "Cute puppies"
+attribution = "Figure Credits: Cute puppies image from unsplash.com"
+attributionlink = 'https://images.unsplash.com/photo-1546238232-20216dec9f72'
+align = "right"
+height = "150"
+width = "150"
+caption = "A figure with right alignment." >}}
+
+{{< /figure >}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
 */}}
 
 {{- $useParams := true -}}


### PR DESCRIPTION
## Description
This PR allows named parameters in the figure shortcode and is an attempt to unify the base Hugo shortcode at [https://github.com/gohugoio/hugo/blob/`@a1cb15e`/tpl/tplimpl/embedded/templates/_shortcodes/figure.html](https://github.com/gohugoio/hugo/blob/a1cb15e1cf9b7606d36552dc31d2ade613318c55/tpl/tplimpl/embedded/templates/_shortcodes/figure.html) with the theme's shortcode.

The change here allows the shortcode to be written in this manner: `{{< figure src="image.jpg" alt="description" >}}`, while preserving backwards compatibility as this is only in a code branch.

I've used [`IsNamedParams`](https://gohugo.io/methods/shortcode/isnamedparams/) to determine what form of shortcode we're using out of the two.

Based on https://gohugo.io/content-management/shortcodes/, the arguments inside the tag all use double-quoted strings, and I found that using single-quoted strings can cause errors that are a little difficult to debug based on Hugo's error messages, so I changed all instances to use double-quoted strings where applicable.

I added another example in the docs right above the shortcode on how to use this syntax. Also, the link to the image of the cute puppies was broken, so I added another one from Unsplash for our floofy friends :)

## Additional context

@goanpeca mentioned as a part of the work on https://github.com/scientific-python-translations/ that this would be nice to support, as Crowdin, as a part of the automations set up for the projects' websites, only understands the named-parameters syntax.