### PR TITLE
docs: assert correct location to use for custom JavaScript files

### DIFF
--- a/doc/content/user_guide/getstarted.md
+++ b/doc/content/user_guide/getstarted.md
@@ -79,7 +79,7 @@ CSS and SCSS files are compiled as Hugo templates, i.e. configuration variables 
 
 ### JavaScript
 
-Add custom JavaScript files to the `./static/js/` directory with a `.js` extension. They will automatically be included in the built pages.
+Add custom JavaScript files to the `./assets/js/` directory with a `.js` extension. They will automatically be included in the built pages.
 
 ## Deploy your site
 


### PR DESCRIPTION
[The "Features" page](https://theme.scientific-python.org/user_guide/features/#custom-javascript) mentioned that custom JavaScript files should go in the `assets/js/` folder, but [the "Get Started" page](https://theme.scientific-python.org/user_guide/getstarted/#javascript) mentioned that they should go in the `static/js/` folder. The comment in

https://github.com/scientific-python/scientific-python-hugo-theme/blob/9f4cf2224b149f545a0da6198389b5249aaf77e1/layouts/partials/javascript.html#L7-L17

is correct here; the `assets/` folder is picked instead (or `assetDir`, if it is set in Hugo's configuration). This PR fixes this mismatch in the docs, and I confirmed with a stub JavaScript file manually to verify.

P.S. I caught this as part of another PR I'm working on!