### PR TITLE
Highlight more of Scientific Python's social media in our footer

### DIFF
--- a/doc/config.yaml
+++ b/doc/config.yaml
@@ -56,8 +56,6 @@ params:
     socialmedia:
       - link: https://github.com/scientific-python/
         icon: github
-      - link: https://www.youtube.com/c/ScientificPython-org
-        icon: youtube
       - link: https://fosstodon.org/@scientific_python
         icon: mastodon
       - link: https://discuss.scientific-python.org


### PR DESCRIPTION
@stefanv, I saw these lying around in the repo; I wonder if it makes sense to add them? We're active on Bluesky, but not on TikTok and Instagram. I'm not sure if TikTok is available in the U.S., either. But I suppose it couldn't hurt to keep these for an international audience.