### PR TITLE
Add partial decorators for better composability

### DIFF
--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.154.0"
+  HUGO_VERSION = "0.154.5"
   DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.152.2"
+  HUGO_VERSION = "0.154.0"
   DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.157.0"
+  HUGO_VERSION = "0.158.0"
   DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 

--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.154.5"
+  HUGO_VERSION = "0.157.0"
   DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -1,0 +1,124 @@
+{{ printf `<?xml version="1.0" encoding="utf-8"?>` | safeHTML }} {{/* ref: https://validator.w3.org/feed/docs/atom.html */}}
+<feed xmlns="http://www.w3.org/2005/Atom"{{ with site.LanguageCode }} xml:lang="{{ . }}"{{ end }}>
+    <generator uri="https://gohugo.io/" version="{{ hugo.Version }}">Hugo</generator>
+    {{- $title := site.Title -}}
+    {{- with .Title -}}
+        {{- if (not (eq . site.Title)) -}}
+            {{- $title = printf `%s %s %s` . (i18n "feed_title_on" | default "on") site.Title -}}
+        {{- end -}}
+    {{- end -}}
+    {{- if .IsTranslated -}}
+        {{ $title = printf "%s (%s)" $title (index site.Data.i18n.languages .Lang) }}
+    {{- end -}}
+    {{ printf `<title type="html"><![CDATA[%s]]></title>` $title | safeHTML }}
+    {{ with (or (.Param "subtitle") (.Param "tagline")) }}
+        {{ printf `<subtitle type="html"><![CDATA[%s]]></subtitle>` . | safeHTML }}
+    {{ end }}
+    {{ $output_formats := .OutputFormats }}
+    {{ range $output_formats -}}
+        {{- $rel := (or (and (eq "atom" (.Name | lower)) "self") "alternate") -}}
+        {{ with $output_formats.Get .Name }}
+            {{ printf `<link href=%q rel=%q type=%q title=%q />` .Permalink $rel .MediaType.Type .Name | safeHTML }}
+        {{- end -}}
+    {{- end }}
+    {{- range .Translations }}
+        {{ $output_formats := .OutputFormats }}
+        {{- $lang := .Lang }}
+        {{- $langstr := index site.Data.i18n.languages .Lang }}
+        {{ range $output_formats -}}
+            {{ with $output_formats.Get .Name }}
+                {{ printf `<link href=%q rel="alternate" type=%q hreflang=%q title="[%s] %s" />` .Permalink .MediaType.Type $lang $langstr .Name | safeHTML }}
+            {{- end -}}
+        {{- end }}
+    {{- end }}
+    <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+    {{ with site.Copyright }}
+        {{- $copyright := replace . "{year}" now.Year -}} {{/* In case the site.copyright uses a special string "{year}" */}}
+        {{- $copyright = replace $copyright "&copy;" "©" -}}
+        <rights>{{ $copyright | plainify }}</rights>
+    {{- end }}
+    {{ with .Param "feed" }}
+        {{/* For this to work, the $icon file should be present in the assets/ directory */}}
+        {{- $icon := .icon | default "icon.svg" -}}
+        {{- with resources.Get $icon -}}
+            <icon>{{ (. | fingerprint).Permalink }}</icon>
+        {{- end }}
+
+        {{/* For this to work, the $logo file should be present in the assets/ directory */}}
+        {{- $logo := .logo | default "logo.svg" -}}
+        {{- with resources.Get $logo -}}
+            <logo>{{ (. | fingerprint).Permalink }}</logo>
+        {{- end }}
+    {{ end }}
+    {{ with site.Params.author }}
+        {{ with .name -}}
+            <author>
+                <name>{{ . }}</name>
+                {{ with $.Site.Params.author.email }}
+                    <email>{{ . }}</email>
+                {{ end -}}
+            </author>
+        {{- end }}
+    {{ end }}
+    {{ with site.Params.id }}
+        <id>{{ . | plainify }}</id>
+    {{ else }}
+        <id>{{ .Permalink }}</id>
+    {{ end }}
+    {{- $limit := (cond (le site.Config.Services.RSS.Limit 0) 65536 site.Config.Services.RSS.Limit) }}
+    {{- $feed_sections := site.Params.feedSections | default site.Params.mainSections -}}
+    {{/* Range through only the pages with a Type in $feed_sections. */}}
+    {{- $pages := where .RegularPages "Type" "in" $feed_sections -}}
+    {{- if (eq .Kind "home") -}}
+        {{- $pages = where site.RegularPages "Type" "in" $feed_sections -}}
+    {{- end -}}
+    {{/* Remove the pages that have the disable_feed parameter set to true. */}}
+    {{- $pages = where $pages ".Params.disable_feed" "!=" true -}}
+    {{/* Remove the pages that have the unlisted parameter set to true. */}}
+    {{- $pages = where $pages ".Params.unlisted" "!=" true -}}
+    {{- range first $limit $pages }}
+        {{ $page := . }}
+        <entry>
+            {{ printf `<title type="html"><![CDATA[%s]]></title>` .Title | safeHTML }}
+            <link href="{{ .Permalink }}?utm_source=atom_feed" rel="alternate" type="text/html" />
+            {{- range .Translations }}
+                {{- $link := printf "%s?utm_source=atom_feed" .Permalink | safeHTML }}
+                {{- printf `<link href=%q rel="alternate" type="text/html" hreflang=%q />` $link .Lang | safeHTML }}
+            {{- end }}
+            {{/* rel=related: See https://validator.w3.org/feed/docs/atom.html#link */}}
+            {{- range first 5 (site.RegularPages.Related .) }}
+                <link href="{{ .Permalink }}?utm_source=atom_feed" rel="related" type="text/html" title="{{ .Title }}" />
+            {{- end }}
+            {{ with .Params.id }}
+                <id>{{ . | plainify }}</id>
+            {{ else }}
+                <id>{{ .Permalink }}</id>
+            {{ end }}
+            {{ with .Params.authors -}}
+                {{- range . -}}
+                    <author>
+                        <name>{{ . }}</name>
+                    </author>
+                {{- end -}}
+            {{- end }}
+            <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
+            <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+            {{ $description1 := .Description | default "" }}
+            {{ $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify))) }}
+            {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
+            {{ with site.Taxonomies }}
+                {{ range $taxo,$_ := . }} <!-- Defaults taxos: "tags", "categories" -->
+                    {{ with $page.Param $taxo }}
+                        {{ $taxo_list := . }} <!-- $taxo_list will be the tags/categories list -->
+                        {{ with site.GetPage (printf "/%s" $taxo) }}
+                            {{ $taxonomy_page := . }}
+                            {{ range $taxo_list }} <!-- Below, assuming pretty URLs -->
+                                <category scheme="taxonomy:{{ printf "%s" $taxo | humanize }}" term="{{ (. | urlize) }}" label="{{ . }}" />
+                            {{ end }}
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+        </entry>
+    {{ end }}
+</feed>

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,11 +1,6 @@
 {{ define "main" }}
 <section class="section content-padding">
-  <div class="content-container">
-    {{ partial "breadcrumbs.html" . }}
-    <h1>{{ .Title }}</h1>
-    {{ if .Params.Subtitle }}
-    <h5 class="subtitle">{{ .Params.Subtitle }}</h5>
-    {{ end }}
+  {{ with partial "_decorators/content-container.html" . }}
     {{ if .Content }}
     {{ .Content }}
     {{ end }}
@@ -20,7 +15,7 @@
       </ul>
     </div>
     {{ end }}
-  </div>
+  {{ end }}
   {{ if .Content }}
   {{ partial "shortcuts.html" . }}
   {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,13 +1,8 @@
 {{ define "main" }}
 <section class="content-padding">
-  <div class="content-container">
-    {{ partial "breadcrumbs.html" . }}
-    <h1>{{ .Title }}</h1>
-    {{ if .Params.Subtitle }}
-    <h5 class="subtitle">{{ .Params.Subtitle }}</h5>
-    {{ end }}
+  {{ with partial "_decorators/content-container.html" . }}
     {{ .Content }}
-  </div>
+  {{ end }}
   {{ partial "shortcuts.html" . }}
 </section>
 {{ end }}

--- a/layouts/partials/_decorators/article.html
+++ b/layouts/partials/_decorators/article.html
@@ -1,0 +1,6 @@
+<article>
+  <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
+  <div>
+    {{- inner . -}}
+  </div>
+</article>

--- a/layouts/partials/_decorators/content-container.html
+++ b/layouts/partials/_decorators/content-container.html
@@ -1,0 +1,8 @@
+<div class="content-container">
+  {{ partial "breadcrumbs.html" . }}
+  <h1>{{ .Title }}</h1>
+  {{ if .Params.Subtitle }}
+  <h5 class="subtitle">{{ .Params.Subtitle }}</h5>
+  {{ end }}
+  {{- inner . -}}
+</div>

--- a/layouts/partials/posts/list-with-summary.html
+++ b/layouts/partials/posts/list-with-summary.html
@@ -2,12 +2,9 @@
 
 <div class="post-list">
   {{ range $posts }}
-  <article>
-    <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
-    <div>
-    {{ partial "posts/meta.html" . }}
-    {{ partial "posts/summary.html" . }}
-    </div>
-  </article>
+    {{ with partial "_decorators/post.html" . }}
+      {{ partial "posts/meta.html" . }}
+      {{ partial "posts/summary.html" . }}
+    {{ end }}
   {{ end }}
 </div>

--- a/layouts/partials/posts/list-with-summary.html
+++ b/layouts/partials/posts/list-with-summary.html
@@ -2,7 +2,7 @@
 
 <div class="post-list">
   {{ range $posts }}
-    {{ with partial "_decorators/post.html" . }}
+    {{ with partial "_decorators/article.html" . }}
       {{ partial "posts/meta.html" . }}
       {{ partial "posts/summary.html" . }}
     {{ end }}

--- a/layouts/partials/posts/list-without-summary.html
+++ b/layouts/partials/posts/list-without-summary.html
@@ -2,11 +2,10 @@
 
 <div class="post-list">
   {{ range $posts }}
-  <article>
-    <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
-    <div class="post-meta">
-      <div>{{ partial "posts/meta.html" . }}</div>
-    </div>
-  </article>
+    {{ with partial "_decorators/post.html" . }}
+      <div class="post-meta">
+        <div>{{ partial "posts/meta.html" . }}</div>
+      </div>
+    {{ end }}
   {{ end }}
 </div>

--- a/layouts/partials/posts/list-without-summary.html
+++ b/layouts/partials/posts/list-without-summary.html
@@ -2,7 +2,7 @@
 
 <div class="post-list">
   {{ range $posts }}
-    {{ with partial "_decorators/post.html" . }}
+    {{ with partial "_decorators/article.html" . }}
       <div class="post-meta">
         <div>{{ partial "posts/meta.html" . }}</div>
       </div>

--- a/layouts/partials/posts/list.html
+++ b/layouts/partials/posts/list.html
@@ -28,18 +28,13 @@
       </ul>
       {{ end }}
   </div>
-  <div class="content-container">
-    {{ partial "breadcrumbs.html" . }}
-    <h1>{{ .Title }}</h1>
-    {{ if .Params.Subtitle }}
-    <h5 class="subtitle">{{ .Params.Subtitle }}</h5>
-    {{ end }}
+  {{ with partial "_decorators/content-container.html" . }}
     {{ if .Content }}
     {{ .Content }}
     {{ end }}
     {{ $posts := .RegularPagesRecursive.ByPublishDate.Reverse }}
     {{ partial "posts/list-without-summary.html" $posts }}
-  </div>
+  {{ end }}
   {{ if .Content }}
   {{ partial "shortcuts.html" . }}
   {{ end }}

--- a/layouts/partials/posts/post.html
+++ b/layouts/partials/posts/post.html
@@ -1,11 +1,6 @@
 {{- $featuredImage := .Resources.GetMatch "featuredImage" -}}
 <section class="post content-padding">
-  <div class="content-container">
-    {{ partial "breadcrumbs.html" . }}
-    <h1>{{ .Title }}</h1>
-    {{ if .Params.Subtitle }}
-    <h5 class="subtitle">{{ .Params.Subtitle }}</h5>
-    {{ end }}
+  {{ with partial "_decorators/content-container.html" . }}
     <div class="post-meta">{{ partial "posts/meta.html" . }}</div>
     <div class="post-content">
       {{ with $featuredImage }}
@@ -18,6 +13,6 @@
       {{ .Content }}
       {{ partial "posts/comments.html" .}}
     </div>
-  </div>
+  {{ end }}
   {{ partial "shortcuts.html" . }}
 </section>

--- a/layouts/partials/posts/post.html
+++ b/layouts/partials/posts/post.html
@@ -1,9 +1,9 @@
-{{- $featuredImage := .Resources.GetMatch "featuredImage" -}}
 <section class="post content-padding">
   {{ with partial "_decorators/content-container.html" . }}
     <div class="post-meta">{{ partial "posts/meta.html" . }}
       <span class="post-please-comment">🖊️ Please add your comments <a href="#discourse-comments">below!</a></span>
     </div>
+    {{- $featuredImage := .Resources.GetMatch "featuredImage" -}}
     <div class="post-content">
       {{ with $featuredImage }}
       {{ if .Params.showOnTop }}

--- a/layouts/partials/section/section.html
+++ b/layouts/partials/section/section.html
@@ -1,10 +1,5 @@
 <section class="content-padding">
-<div class="content-container">
-  {{ partial "breadcrumbs.html" . }}
-  <h1>{{ .Title }}</h1>
-  {{ if .Params.Subtitle }}
-  <h5 class="subtitle">{{ .Params.Subtitle }}</h5>
-  {{ end }}
+{{ with partial "_decorators/content-container.html" . }}
   {{ if .Content }}
   {{ .Content }}
   {{ else }}
@@ -25,7 +20,7 @@
   </div>
   {{ end }}
   {{ end }}
-</div>
+{{ end }}
 <div id="shortcuts-container">
   <div id="shortcuts">
     <div id="shortcuts-header"><i class="fa-solid fa-list"></i> On this page</div>


### PR DESCRIPTION
This PR introduces partial decorators, a new feature in Hugo released with v0.154.0: https://github.com/gohugoio/hugo/releases/tag/v0.154.0. This will not be a user-facing change. The documentation is at https://gohugo.io/functions/templates/inner/ and is currently a bit sparse, but still understandable. From the [docs](https://gohugo.io/quick-reference/glossary/#partial-decorator): I have bumped to Hugo 0.155.0 with this PR, which is as far as we can go right now.

_A partial decorator is a [partial](https://gohugo.io/quick-reference/glossary/#partial) template called from any other template including [shortcodes](https://gohugo.io/quick-reference/glossary/#shortcode), [render hooks](https://gohugo.io/quick-reference/glossary/#render-hook), and other partials._

There are some more examples here: https://github.com/gohugoio/hugoDocs/pull/3330.

I also tried to add something to deduplicate the grid of items and cards, but that turned out to be more complicated – the content inside needs access to outer variables such as `$card` and `.body`. I think we can go ahead with this, for now at least, since it's a net win for easy deduplication either way, and we can do this kind of work incrementally.