### PR TITLE
Add Lato as a default font

### DIFF
--- a/assets/theme-css/navbar.css
+++ b/assets/theme-css/navbar.css
@@ -18,6 +18,7 @@
 .navbar-logo-text {
   font-size: 1.25rem;
   font-weight: 700;
+  font-family: "Lato", sans-serif;
 }
 .navbar .container {
   min-height: 4rem;

--- a/doc/config.yaml
+++ b/doc/config.yaml
@@ -26,9 +26,6 @@ params:
     image: logo.svg
     text: Scientific Python Hugo Theme
     link: /
-  fonts:
-    - name: "Lato"
-      weights: [400, 900]
   hero:
     title: Scientific Python Theme
     image: logo.svg

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -26,9 +26,6 @@ params:
     image: logo.svg
     text: Scientific Python Hugo Theme
     link: /
-  fonts:
-    - name: "Lato"
-      weights: [400, 900]
   hero:
     title: Example Site
     image: logo.svg

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -21,8 +21,13 @@
 
 <link rel="icon" href="{{ "images/favicon.ico" | relURL }}" />
 
-<!-- Fallback font for symbols (such as "🛈"). --
+<!-- Fallback font for symbols (such as "🛈"). -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols+2">
+
+<!-- Default theme font (Lato). -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700">
 
 <!-- Process and include Sass files. -->
 {{- $sass := append (resources.Get "theme-css/sphinx-design/index.scss")


### PR DESCRIPTION
the `fonts:` section in the Hugo config is supposed to be for _additional_ fonts that users want to include for whatever reason, but we've been relying on Lato for downstream websites and it makes sense to add it here. Also enables Noto Sans which was disabled for some reason (inadvertently, based on the incorrect comment?).

Closes #705 

- [x] check Blog site deploy preview, which doesn't have Lato yet until https://github.com/scientific-python/blog.scientific-python.org/pull/268 will be merged
- [x] check Learn site deploy preview, which doesn't have Lato
- [x] check SciPy