### PR TITLE
Change .Site.LanguageCode to .Site.Language.Locale

### DIFF
--- a/doc/netlify.toml
+++ b/doc/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.152.2"
+  HUGO_VERSION = "0.158.0"
   DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -1,5 +1,5 @@
 baseURL: "https://example.com/"
-languageCode: "en-us"
+locale: "en-us"
 title: "Example Site"
 theme: scientific-python-hugo-theme
 relativeURLs: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}" data-colorscheme="{{ .Site.Params.colorScheme }}" >
+<html lang="{{ .Site.Language.Locale }}" data-colorscheme="{{ .Site.Params.colorScheme }}" >
   <head>
     {{ print "<!-- Generated " (time.Now.UTC.Format "2006-01-02 15:04:05 UTC") " -->" | safeHTML }}
     {{ partial "meta.html" . }}


### PR DESCRIPTION
This PR fixes #711 by replacing the deprecated `.Site.LanguageCode` to with `.Site.Language.Locale` (see [hugo docs](https://gohugo.io/methods/site/language/#locale))